### PR TITLE
Install either docker or docker-py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,33 @@
 #!/usr/bin/env python3
 
+import os
 from setuptools import setup
 
 install_requires = [
     'distro',
-    'docker-py',
     'empy',
     'pexpect',
 ]
+
+# docker API used to be in a package called `docker-py` before the 2.0 release
+docker_package = 'docker'
+try:
+    import docker
+except ImportError:
+    # Docker is not yet installed, pick library based on platform
+    # Use old name if platform has pre-2.0 version
+    if os.path.isfile('/etc/os-release'):
+        with open('/etc/os-release') as fin:
+            content = fin.read()
+        if 'xenial' in content:
+            docker_package = 'docker-py'
+else:
+    # Docker is installed, pick library based on what we found
+    ver = docker.__version__.split('.')
+    if int(ver[0]) < 2:
+        docker_package = 'docker-py'
+
+install_requires.append(docker_package)
 
 kwargs = {
     'name': 'rocker',

--- a/src/rocker/cli.py
+++ b/src/rocker/cli.py
@@ -51,7 +51,11 @@ def main():
     base_image = args.image
 
     if args.pull:
-        docker_client = docker.APIClient()
+        try:
+            docker_client = docker.APIClient()
+        except AttributeError:
+            # docker-py pre 2.0
+            docker_client = docker.Client()
         try:
             print("Pulling image %s" % base_image)
             for line in docker_client.pull(base_image, stream=True):

--- a/src/rocker/core.py
+++ b/src/rocker/core.py
@@ -59,7 +59,11 @@ class DockerImageGenerator(object):
             arguments['tag'] = self.image_name
             print("Building docker file with arguments: ", arguments)
             try:
-                docker_client = docker.APIClient()
+                try:
+                    docker_client = docker.APIClient()
+                except AttributeError:
+                    # docker-py pre 2.0
+                    docker_client = docker.Client()
                 success_detected = False
                 for line in docker_client.build(**arguments):
                     output = line.get('stream', '').rstrip()


### PR DESCRIPTION
Fixes #17 

On `xenial` I ran `python setup.py install`:
* with `docker-py==1.8.0` installed
   * pip freeze shows only `docker-py` is installed
   * `rocker fedora bash` and `rocker --pull fedora bash` worked correctly
* with `docker` installed
   * pip freeze shows only `docker` is installed
   * `rocker fedora bash` and `rocker --pull fedora bash` worked correctly
* with nothing installed
   * pip freeze shows `docker-py` was installed


Have NOT tested:
* bionic