### PR TITLE
Enable detection of the OS in the image

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ kwargs = {
     'entry_points': {
         'console_scripts': [
             'rocker = rocker.cli:main',
+            'detect_docker_image_os = rocker.cli:detect_image_os',
 	    ],
         'rocker.extensions': [
             'dev_helpers = rocker.extensions:DevHelpers',

--- a/src/rocker/cli.py
+++ b/src/rocker/cli.py
@@ -22,6 +22,9 @@ from .core import DockerImageGenerator
 from .core import list_plugins
 from .core import pull_image
 
+from .os_detector import build_detector_image
+from .os_detector import detect_os
+
 
 def main():
 
@@ -60,3 +63,17 @@ def main():
     args.command = ' '.join(args.command)
     return dig.run(**args_dict)
 
+
+def detect_image_os():
+    parser = argparse.ArgumentParser(description='Detect the os in an image')
+    parser.add_argument('image')
+
+    args = parser.parse_args()    
+
+    build_detector_image()
+    results = detect_os(args.image)
+    print(results)
+    if results:
+        return 0
+    else:
+        return 1

--- a/src/rocker/os_detector.py
+++ b/src/rocker/os_detector.py
@@ -1,0 +1,75 @@
+# Copyright 2019 Open Source Robotics Foundation
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pexpect
+
+from ast import literal_eval 
+from io import BytesIO as StringIO
+
+from .core import get_docker_client
+
+
+DETECTOR_DOCKERFILE="""
+FROM python:3
+
+RUN mkdir -p /tmp/distrovenv
+RUN python3 -m venv /tmp/distrovenv
+RUN . /tmp/distrovenv/bin/activate && pip install distro pyinstaller
+
+RUN echo 'import distro; print(distro.linux_distribution())' > /tmp/distrovenv/detect_os.py
+RUN . /tmp/distrovenv/bin/activate && pyinstaller --onefile /tmp/distrovenv/detect_os.py
+
+"""
+
+DETECTION_TEMPLATE="""
+FROM rocker__detector as detector
+
+FROM %(image_name)s
+
+COPY --from=detector /dist/detect_os /tmp/detect_os
+CMD /tmp/detect_os
+"""
+
+
+def build_detector_image():
+    client = get_docker_client()
+    """Build the image to use to detect the OS"""
+    dockerfile_tag = 'rocker__detector'
+    iof = StringIO(DETECTOR_DOCKERFILE.encode())
+    im = client.build(fileobj = iof, tag=dockerfile_tag)
+    for l in im:
+        pass
+        #print(l)
+
+
+def detect_os(image_name):
+    client = get_docker_client()
+    dockerfile_tag = 'rocker__detection_%s' % image_name
+    iof = StringIO((DETECTION_TEMPLATE % locals()).encode())
+    im = client.build(fileobj = iof, tag=dockerfile_tag)
+    for l in im:
+        pass
+        #print(l)
+    
+
+    cmd="docker run -it --rm %s" % dockerfile_tag
+    try:
+        p = pexpect.spawn(cmd)
+        output = p.read()
+        p.terminate()
+        return literal_eval(output.decode().strip())
+    except subprocess.CalledProcessError as ex:
+        print("Docker run failed\n", ex)
+        print(ex.output)
+        return None

--- a/src/rocker/os_detector.py
+++ b/src/rocker/os_detector.py
@@ -64,12 +64,10 @@ def detect_os(image_name):
     
 
     cmd="docker run -it --rm %s" % dockerfile_tag
-    try:
-        p = pexpect.spawn(cmd)
-        output = p.read()
-        p.terminate()
+    p = pexpect.spawn(cmd)
+    output = p.read()
+    p.terminate()
+    if p.exitstatus == 0:
         return literal_eval(output.decode().strip())
-    except subprocess.CalledProcessError as ex:
-        print("Docker run failed\n", ex)
-        print(ex.output)
+    else:
         return None

--- a/test/test_os_detect.py
+++ b/test/test_os_detect.py
@@ -1,0 +1,47 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import docker
+import unittest
+
+
+from rocker.os_detector import build_detector_image
+from rocker.os_detector import detect_os
+
+class RockerOSDetectorTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(self):
+        build_detector_image()
+
+    def test_ubuntu(self):
+        result = detect_os("ubuntu:xenial")
+        self.assertEqual(result[0], 'Ubuntu')
+        self.assertEqual(result[1], '16.04')
+
+        result = detect_os("ubuntu:bionic")
+        self.assertEqual(result[0], 'Ubuntu')
+        self.assertEqual(result[1], '18.04')
+
+    def test_fedora(self):
+        result = detect_os("fedora:29")
+        self.assertEqual(result[0], 'Fedora')
+        self.assertEqual(result[1], '29')
+
+    def test_does_not_exist(self):
+        result = detect_os("osrf/ros:does_not_exist")
+        self.assertEqual(result, None)


### PR DESCRIPTION
This will allow the snippets and multi layer builds to adjust to the image they are overlaying onto appropriately. This is what most of the things should be parameterized on not the host.