### PR TITLE
Add No-Python2 flag

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,8 +1,7 @@
 [rocker]
 Debian-Version: 100
-;Depends: PYTHON 3 ONLY
+No-Python2:
 Depends3: python3-docker, python3-empy, python3-pexpect
-;Conflicts: python3-rocker
 Conflicts3: python-rocker
 Suite: xenial yakkety zesty artful bionic stretch buster
 X-Python3-Version: >= 3.2


### PR DESCRIPTION
Instead of the comment and no dependencies

Re: https://github.com/ros-infrastructure/ros_release_python/pull/28