### PR TITLE
More user details while creating a user inside container

### DIFF
--- a/src/rocker/extensions.py
+++ b/src/rocker/extensions.py
@@ -123,10 +123,11 @@ class User(RockerExtension):
 
     def get_environment_subs(self):
         if not self._env_subs:
+            user_vars = ['name', 'uid', 'gid', 'gecos','dir', 'shell']
             userinfo = pwd.getpwuid(os.getuid())
             self._env_subs = {
                 k: getattr(userinfo, 'pw_' + k)
-                for k in "name uid gid gecos dir shell".split() }
+                for k in user_vars }
         return self._env_subs
 
     def __init__(self):

--- a/src/rocker/extensions.py
+++ b/src/rocker/extensions.py
@@ -16,6 +16,7 @@ import grp
 import os
 import em
 import getpass
+import pwd
 import pkgutil
 from pathlib import Path
 import subprocess
@@ -122,9 +123,10 @@ class User(RockerExtension):
 
     def get_environment_subs(self):
         if not self._env_subs:
-            self._env_subs = {}
-            self._env_subs['user_id'] = os.getuid()
-            self._env_subs['username'] = getpass.getuser()
+            userinfo = pwd.getpwuid(os.getuid())
+            self._env_subs = {
+                k: getattr(userinfo, 'pw_' + k)
+                for k in "name uid gid gecos dir shell".split() }
         return self._env_subs
 
     def __init__(self):

--- a/src/rocker/templates/user_snippet.Dockerfile.em
+++ b/src/rocker/templates/user_snippet.Dockerfile.em
@@ -5,7 +5,7 @@ RUN apt-get update \
  && apt-get clean
 
 @[if username != 'root']@
-RUN useradd -U --uid @(user_id) -ms /bin/bash @(username) \
+RUN useradd -U --uid @(uid) -ms @(shell) @(name) -c @(gecos) -g @(gid) -d @(dir) \
  && echo "@(username):@(username)" | chpasswd \
  && adduser @(username) sudo \
  && echo "@(username) ALL=NOPASSWD: ALL" >> /etc/sudoers.d/@(username)

--- a/src/rocker/templates/user_snippet.Dockerfile.em
+++ b/src/rocker/templates/user_snippet.Dockerfile.em
@@ -4,13 +4,14 @@ RUN apt-get update \
     sudo \
  && apt-get clean
 
-@[if username != 'root']@
-RUN useradd -U --uid @(uid) -ms @(shell) @(name) -c @(gecos) -g @(gid) -d @(dir) \
- && echo "@(username):@(username)" | chpasswd \
- && adduser @(username) sudo \
- && echo "@(username) ALL=NOPASSWD: ALL" >> /etc/sudoers.d/@(username)
+@[if name != 'root']@
+RUN groupadd -g @(gid) @name \
+ && useradd --uid @(uid) -s @(shell) @(name) -c @(gecos) -g @(gid) -d @(dir) \
+ && echo "@(name):@(name)" | chpasswd \
+ && adduser @(name) sudo \
+ && echo "@(name) ALL=NOPASSWD: ALL" >> /etc/sudoers.d/@(name)
 # Commands below run as the developer user
-USER @(username)
+USER @(name)
 @[else]@
 # Detected user is root, which already exists so not creating new user.
 @[end if]@

--- a/src/rocker/templates/user_snippet.Dockerfile.em
+++ b/src/rocker/templates/user_snippet.Dockerfile.em
@@ -5,8 +5,8 @@ RUN apt-get update \
  && apt-get clean
 
 @[if name != 'root']@
-RUN groupadd -g @(gid) @name \
- && useradd --uid @(uid) -s @(shell) @(name) -c @(gecos) -g @(gid) -d @(dir) \
+RUN groupadd -g "@(gid)" "@name" \
+ && useradd --uid "@(uid)" -s "@(shell)" -c "@(gecos)" -g "@(gid)" -d "@(dir)" "@(name)" \
  && echo "@(name):@(name)" | chpasswd \
  && adduser @(name) sudo \
  && echo "@(name) ALL=NOPASSWD: ALL" >> /etc/sudoers.d/@(name)

--- a/test/test_extension.py
+++ b/test/test_extension.py
@@ -21,6 +21,7 @@ import getpass
 import os
 import unittest
 from pathlib import Path
+import pwd
 
 
 from rocker.cli import list_plugins
@@ -97,8 +98,12 @@ class UserExtensionTest(unittest.TestCase):
         self.assertTrue(plugin_load_parser_correctly(user_plugin))
 
         env_subs = p.get_environment_subs()
+        self.assertEqual(env_subs['gid'], os.getgid())
         self.assertEqual(env_subs['uid'], os.getuid())
         self.assertEqual(env_subs['name'],  getpass.getuser())
+        self.assertEqual(env_subs['dir'],  str(Path.home()))
+        self.assertEqual(env_subs['gecos'],  pwd.getpwuid(os.getuid()).pw_gecos)
+        self.assertEqual(env_subs['shell'],  pwd.getpwuid(os.getuid()).pw_shell)
 
         mock_cliargs = {}
         snippet = p.get_snippet(mock_cliargs).splitlines()

--- a/test/test_extension.py
+++ b/test/test_extension.py
@@ -97,8 +97,8 @@ class UserExtensionTest(unittest.TestCase):
         self.assertTrue(plugin_load_parser_correctly(user_plugin))
 
         env_subs = p.get_environment_subs()
-        self.assertEqual(env_subs['user_id'], os.getuid())
-        self.assertEqual(env_subs['username'],  getpass.getuser())
+        self.assertEqual(env_subs['uid'], os.getuid())
+        self.assertEqual(env_subs['name'],  getpass.getuser())
 
         mock_cliargs = {}
         snippet = p.get_snippet(mock_cliargs).splitlines()


### PR DESCRIPTION
With a non-default home directory, `rocker --home --user --x11 ubuntu:18.04` creates a different home directory. This should probably not be the intended behaviour. 

I have modified the UserExtension to create user with more fields same as the current user. Now the fields, include the shell, group id and home directory.