### PR TITLE
Add Cosmic, Disco, and Eoan suites.

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -3,5 +3,5 @@ Debian-Version: 100
 No-Python2:
 Depends3: python3-docker, python3-empy, python3-pexpect
 Conflicts3: python-rocker
-Suite: xenial yakkety zesty artful bionic stretch buster
+Suite: xenial yakkety zesty artful bionic cosmic disco eoan stretch buster
 X-Python3-Version: >= 3.2


### PR DESCRIPTION
These are now live on the ROS bootstrap repository and future releases should be pushed to them as well.