### PR TITLE
Fix OS detection

### DIFF
--- a/src/rocker/os_detector.py
+++ b/src/rocker/os_detector.py
@@ -21,7 +21,7 @@ from .core import get_docker_client
 
 
 DETECTOR_DOCKERFILE="""
-FROM python:3
+FROM python:3-stretch
 
 RUN mkdir -p /tmp/distrovenv
 RUN python3 -m venv /tmp/distrovenv
@@ -38,7 +38,8 @@ FROM rocker__detector as detector
 FROM %(image_name)s
 
 COPY --from=detector /dist/detect_os /tmp/detect_os
-CMD /tmp/detect_os
+ENTRYPOINT [ "/tmp/detect_os" ]
+CMD [ "" ]
 """
 
 


### PR DESCRIPTION
Fixes #43 (platform detection breaks nvidia plugin if the entrypoint is invalid).
Check https://github.com/osrf/rocker/issues/43#issuecomment-523476166 for my analysis of the root cause. It is not directly related to nvidia or entrypoints.

This patch changes the base image to compile the `detect_os` binary from `python:3` to `python:3-stretch`, such that it does not depend on libc 2.28. But maybe it would be easier to distribute a copy of the `detect_os` binary with rocker?

I also replaced the `CMD` by an overwritten `ENTRYPOINT`, such that the OS detection and nvidia extension also work with containers which already have an incompatible entrypoint defined.