### PR TITLE
Fix using rocker for non-root containers

### DIFF
--- a/src/rocker/cli.py
+++ b/src/rocker/cli.py
@@ -46,7 +46,7 @@ def main():
     args_dict = vars(args)
     
     active_extensions = [e() for e in plugins.values() if args_dict.get(e.get_name())]
-    # Force user to end if present otherwise it will 
+    # Force user to end if present otherwise it will break other extensions
     active_extensions.sort(key=lambda e:e.get_name().startswith('user'))
     print("Active extensions %s" % [e.get_name() for e in active_extensions])
 

--- a/src/rocker/core.py
+++ b/src/rocker/core.py
@@ -180,9 +180,6 @@ def generate_dockerfile(extensions, args_dict, base_image):
         dockerfile_str += el.get_preamble(args_dict) + '\n'
     dockerfile_str += '\nFROM %s\n' % base_image
     dockerfile_str += 'USER root\n'
-    if 'user' in extensions:
-        extensions.remove('user')
-        extensions.append('user')
     for el in extensions:
         dockerfile_str += '# Snippet from extension [%s]\n' % el.name
         dockerfile_str += el.get_snippet(args_dict) + '\n'

--- a/src/rocker/core.py
+++ b/src/rocker/core.py
@@ -179,6 +179,10 @@ def generate_dockerfile(extensions, args_dict, base_image):
         dockerfile_str += '# Preamble from extension [%s]\n' % el.name
         dockerfile_str += el.get_preamble(args_dict) + '\n'
     dockerfile_str += '\nFROM %s\n' % base_image
+    dockerfile_str += 'USER root\n'
+    if 'user' in extensions:
+        extensions.remove('user')
+        extensions.append('user')
     for el in extensions:
         dockerfile_str += '# Snippet from extension [%s]\n' % el.name
         dockerfile_str += el.get_snippet(args_dict) + '\n'

--- a/src/rocker/extensions.py
+++ b/src/rocker/extensions.py
@@ -142,6 +142,6 @@ class User(RockerExtension):
     def register_arguments(parser):
         parser.add_argument(name_to_argument(User.get_name()),
             action='store_true',
-            help="mount the users home directory")
+            help="run the container with the uid/gid of the host user")
 
 

--- a/src/rocker/templates/user_snippet.Dockerfile.em
+++ b/src/rocker/templates/user_snippet.Dockerfile.em
@@ -19,7 +19,7 @@ RUN existing_user_by_uid=`getent passwd "@(uid)" | cut -f1 -d: || true` && \
 
 @[if not home_extension_active ]@
 # Making sure a home directory exists if we haven't mounted the user's home directory explicitly
-RUN mkhomedir_helper @(name)
+RUN mkdir -p "$(dirname "@(dir)")" && mkhomedir_helper @(name)
 @[end if]@
 # Commands below run as the developer user
 USER @(name)

--- a/src/rocker/templates/user_snippet.Dockerfile.em
+++ b/src/rocker/templates/user_snippet.Dockerfile.em
@@ -5,10 +5,11 @@ RUN apt-get update \
  && apt-get clean
 
 @[if name != 'root']@
-RUN groupadd -g "@(gid)" "@name" \
- && useradd --uid "@(uid)" -s "@(shell)" -c "@(gecos)" -g "@(gid)" -d "@(dir)" "@(name)" \
- && echo "@(name):@(name)" | chpasswd \
- && adduser @(name) sudo \
+RUN (getent group "@(gid)" >/dev/null || groupadd -g "@(gid)" "@name") \
+ && (getent passwd "@(uid)" >/dev/null || \
+       useradd --no-log-init --uid "@(uid)" -s "@(shell)" -c "@(gecos)" -g "@(gid)" -d "@(dir)" "@(name)" -m \
+       && echo "@(name):@(name)" | chpasswd \
+       && adduser @(name) sudo) \
  && echo "@(name) ALL=NOPASSWD: ALL" >> /etc/sudoers.d/@(name)
 # Commands below run as the developer user
 USER @(name)

--- a/src/rocker/templates/user_snippet.Dockerfile.em
+++ b/src/rocker/templates/user_snippet.Dockerfile.em
@@ -6,9 +6,9 @@ RUN apt-get update \
 
 @[if name != 'root']@
 RUN existing_user_by_uid=`getent passwd "@(uid)" | cut -f1 -d: || true` && \
-    if [ -n "${existing_user_by_uid}" ]; then userdel -r "${existing_user_by_uid}"; fi && \
+    if [ -n "${existing_user_by_uid}" ]; then userdel -r "${existing_user_by_uid}" 2>&1 | grep -v "not found"; fi && \
     existing_user_by_name=`getent passwd "@(name)" | cut -f1 -d: || true` && \
-    if [ -n "${existing_user_by_name}" ]; then userdel -r "${existing_user_by_name}"; fi && \
+    if [ -n "${existing_user_by_name}" ]; then userdel -r "${existing_user_by_name}" 2>&1 | grep -v "not found"; fi && \
     existing_group_by_gid=`getent group "@(gid)" | cut -f1 -d: || true` && \
     if [ -z "${existing_group_by_gid}" ]; then \
       groupadd -g "@(gid)" "@name"; \

--- a/src/rocker/templates/user_snippet.Dockerfile.em
+++ b/src/rocker/templates/user_snippet.Dockerfile.em
@@ -6,9 +6,9 @@ RUN apt-get update \
 
 @[if name != 'root']@
 RUN existing_user_by_uid=`getent passwd "@(uid)" | cut -f1 -d: || true` && \
-    if [ -n "${existing_user_by_uid}" ]; then userdel -r "${existing_user_by_uid}" 2>&1 | grep -v "not found"; fi && \
+    if [ -n "${existing_user_by_uid}" ]; then userdel -r "${existing_user_by_uid}"; fi && \
     existing_user_by_name=`getent passwd "@(name)" | cut -f1 -d: || true` && \
-    if [ -n "${existing_user_by_name}" ]; then userdel -r "${existing_user_by_name}" 2>&1 | grep -v "not found"; fi && \
+    if [ -n "${existing_user_by_name}" ]; then userdel -r "${existing_user_by_name}"; fi && \
     existing_group_by_gid=`getent group "@(gid)" | cut -f1 -d: || true` && \
     if [ -z "${existing_group_by_gid}" ]; then \
       groupadd -g "@(gid)" "@name"; \

--- a/test/test_extension.py
+++ b/test/test_extension.py
@@ -108,9 +108,6 @@ class UserExtensionTest(unittest.TestCase):
         mock_cliargs = {}
         snippet = p.get_snippet(mock_cliargs).splitlines()
 
-        passwd_line = [l for l in snippet if 'chpasswd' in l][0]
-        self.assertTrue(getpass.getuser() in passwd_line)
-
         uid_line = [l for l in snippet if '--uid' in l][0]
         self.assertTrue(str(os.getuid()) in uid_line)
 


### PR DESCRIPTION
If the base image given by the user does not have root privileges, building the rockerized image will fail. Extensions seem to expect that their Dockerfile snippets are executed with root privileges.

This patch injects a `USER root` instruction right after `FROM base_image`. It is a no-op if the base image already runs as the `root` user.

For similar reasons the `user` extension has to run last, because its snippet changes the active user again and subsequent snippets from other extensions might fail. But this is a special case only. Maybe the extension API should have a more general way to declare dependencies of extensions. For example, `nvidia` depends on `x11`. Without specifying both, I cannot run 3D-accelerated GUI applications in the rockerized container.