### PR TITLE
Add extension to pass custom environment variables

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ kwargs = {
 	    ],
         'rocker.extensions': [
             'dev_helpers = rocker.extensions:DevHelpers',
+            'env = rocker.extensions:Environment',
             'nvidia = rocker.nvidia_extension:Nvidia',
             'pulse = rocker.extensions:PulseAudio',
             'home = rocker.extensions:HomeDir',

--- a/src/rocker/extensions.py
+++ b/src/rocker/extensions.py
@@ -19,6 +19,7 @@ import getpass
 import pwd
 import pkgutil
 from pathlib import Path
+from shlex import quote
 import subprocess
 import sys
 
@@ -145,3 +146,28 @@ class User(RockerExtension):
             help="mount the users home directory")
 
 
+class Environment(RockerExtension):
+    @staticmethod
+    def get_name():
+        return 'env'
+
+    def __init__(self):
+        self.name = Environment.get_name()
+
+    def get_snippet(self, cli_args):
+        return ''
+
+    def get_docker_args(self, cli_args):
+        args = ['']
+        for env in cli_args['env']:
+            args.append('-e {0}'.format(quote(env)))
+
+        return ' '.join(args)
+
+    @staticmethod
+    def register_arguments(parser):
+        parser.add_argument('--env',
+            metavar='NAME[=VALUE]',
+            type=str,
+            nargs='+',
+            help='set environment variables')


### PR DESCRIPTION
Mimics the `-e, --env` option of `docker run`:
```
       -e, --env=[]
          Set environment variables

       This option allows you to specify arbitrary environment variables that are available for the process that will be launched inside of the container.
```

Probably [shlex.quote](https://docs.python.org/3/library/shlex.html#shlex.quote) should be applied to other extensions that allow the user to pass custom command line arguments, too, for example #46.