### PR TITLE
Enable rocker to be used with images pulled from private registries

### DIFF
--- a/src/rocker/core.py
+++ b/src/rocker/core.py
@@ -28,6 +28,8 @@ import em
 import docker
 import pexpect
 
+from .utils import tag_image_name
+
 class RockerExtension(object):
     """The base class for Rocker extension points"""
 
@@ -76,11 +78,10 @@ class DockerImageGenerator(object):
 
         self.dockerfile = generate_dockerfile(active_extensions, self.cliargs, base_image)
         # print(df)
-        self.image_name = "rocker_" + base_image
+        self.image_name = tag_image_name(base_image, prefix="rocker-")
         if self.active_extensions:
-            self.image_name += "_%s" % '_'.join([e.name for e in active_extensions])
+            self.image_name += "-%s" % '-'.join([e.name for e in active_extensions])
 
-    
     def build(self, **kwargs):
         with tempfile.TemporaryDirectory() as td:
             df = os.path.join(td, 'Dockerfile')

--- a/src/rocker/os_detector.py
+++ b/src/rocker/os_detector.py
@@ -18,6 +18,7 @@ from ast import literal_eval
 from io import BytesIO as StringIO
 
 from .core import get_docker_client
+from .utils import tag_image_name
 
 
 DETECTOR_DOCKERFILE="""
@@ -67,7 +68,7 @@ def build_detector_image(verbose=False):
 
 def detect_os(image_name):
     client = get_docker_client()
-    dockerfile_tag = 'rocker__detection_%s' % image_name
+    dockerfile_tag = tag_image_name(image_name, prefix='rocker--detection-')
     iof = StringIO((DETECTION_TEMPLATE % locals()).encode())
     im = client.build(fileobj = iof, tag=dockerfile_tag)
     for l in im:

--- a/src/rocker/utils.py
+++ b/src/rocker/utils.py
@@ -18,7 +18,7 @@ from argparse import ArgumentTypeError
 def tag_image_name(image_name, prefix=None, suffix=None):
     # from https://github.com/docker/distribution/blob/master/reference/reference.go, with some simplifications:
     parsed_image_name = re.fullmatch(
-        r'((?P<hostname>([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+)(:(?P<port>[0-9]+))?/)?'
+        r'((?P<hostname>([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))*)(:(?P<port>[0-9]+))?/)?'
         r'(?P<components>[a-zA-Z0-9_\.-]+(/[a-zA-Z0-9_\.-]+)*)'
         r'(:(?P<tag>[a-zA-Z0-9\.-]+))?',
         image_name)

--- a/src/rocker/utils.py
+++ b/src/rocker/utils.py
@@ -1,0 +1,45 @@
+# Copyright 2019 Open Source Robotics Foundation
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+from argparse import ArgumentTypeError
+
+def tag_image_name(image_name, prefix=None, suffix=None):
+    # from https://github.com/docker/distribution/blob/master/reference/reference.go, with some simplifications:
+    parsed_image_name = re.fullmatch(
+        r'((?P<hostname>([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+)(:(?P<port>[0-9]+))?/)?'
+        r'(?P<components>[a-zA-Z0-9_\.-]+(/[a-zA-Z0-9_\.-]+)*)'
+        r'(:(?P<tag>[a-zA-Z0-9\.-]+))?',
+        image_name)
+    if not parsed_image_name:
+        raise ArgumentTypeError('image name is not a valid Docker image reference')
+
+    # convert matched groups to a dictionary and remove None elements
+    parsed_image_name = {k: v for k, v in parsed_image_name.groupdict().items() if v is not None}
+
+    tagged_name = ''
+    if 'hostname' in parsed_image_name:
+        tagged_name += parsed_image_name['hostname']
+        if 'port' in parsed_image_name:
+            tagged_name += ':{}'.format(parsed_image_name['port'])
+        tagged_name += '/'
+    tagged_name += parsed_image_name['components']
+
+    tag = parsed_image_name.get('tag', 'latest')
+    tagged_name += ':{prefix}{tag}{suffix}'.format(
+        prefix=(prefix or ''),
+        tag=(tag or ''),
+        suffix=(suffix or ''))
+
+    return tagged_name

--- a/test/test_os_detect.py
+++ b/test/test_os_detect.py
@@ -43,5 +43,5 @@ class RockerOSDetectorTest(unittest.TestCase):
         self.assertEqual(result[1], '29')
 
     def test_does_not_exist(self):
-        result = detect_os("osrf/ros:does_not_exist")
+        result = detect_os("osrf/ros:does-not-exist")
         self.assertEqual(result, None)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,0 +1,84 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from argparse import ArgumentTypeError
+from nose.tools import assert_raises
+import unittest
+
+from rocker.utils import tag_image_name
+
+class RockerTagImageNameTest(unittest.TestCase):
+
+    def test_tag_image_name(self):
+        # simple names without host or tags
+        self.assertEqual(
+            tag_image_name('image', prefix='rocker-', suffix='-tags'),
+            'image:rocker-latest-tags')
+        self.assertEqual(
+            tag_image_name('user/image', prefix='rocker-', suffix='-tags'),
+            'user/image:rocker-latest-tags')
+        self.assertEqual(
+            tag_image_name('more/than/two/components', prefix='rocker-', suffix='-tags'),
+            'more/than/two/components:rocker-latest-tags')
+
+        # with custom tag
+        self.assertEqual(
+            tag_image_name('image:custom-1.2.3', prefix='rocker-', suffix='-tags'),
+            'image:rocker-custom-1.2.3-tags')
+        self.assertEqual(
+            tag_image_name('user/image:custom-1.2.3', prefix='rocker-', suffix='-tags'),
+            'user/image:rocker-custom-1.2.3-tags')
+
+        # with host localhost and port 5000 (default for https://docs.docker.com/registry/deploying/)
+        self.assertEqual(
+            tag_image_name('localhost:5000/user/image', prefix='rocker-', suffix='-tags'),
+            'localhost:5000/user/image:rocker-latest-tags')
+        self.assertEqual(
+            tag_image_name('localhost:5000/user/image:custom-1.2.3', prefix='rocker-', suffix='-tags'),
+            'localhost:5000/user/image:rocker-custom-1.2.3-tags')
+
+        # with fully-qualified domain without port
+        self.assertEqual(
+            tag_image_name('my.private.registry/user/image', prefix='rocker-', suffix='-tags'),
+            'my.private.registry/user/image:rocker-latest-tags')
+        self.assertEqual(
+            tag_image_name('my.private.registry/user/image:custom-1.2.3', prefix='rocker-', suffix='-tags'),
+            'my.private.registry/user/image:rocker-custom-1.2.3-tags')
+
+        # with fully-qualified domain and port
+        self.assertEqual(
+            tag_image_name('my.private.registry:5000/user/image', prefix='rocker-', suffix='-tags'),
+            'my.private.registry:5000/user/image:rocker-latest-tags')
+        self.assertEqual(
+            tag_image_name('my.private.registry:5000/user/image:custom-1.2.3', prefix='rocker-', suffix='-tags'),
+            'my.private.registry:5000/user/image:rocker-custom-1.2.3-tags')
+
+        # test some invalid names
+        assert_raises(ArgumentTypeError, tag_image_name,
+            'image:tags_must_only_contain_alphanumeric_characters_dots_and_dashes')
+        assert_raises(ArgumentTypeError, tag_image_name,
+            'hostnames_cannot_have_undescores.example.com:5000/user/image')
+
+        # You might think that this name is invalid, but docker interprets the
+        # first item as a component part if there is no port:
+        self.assertEqual(
+            tag_image_name('hostnames_cannot_have_undescores.example.com/user/image'),
+            'hostnames_cannot_have_undescores.example.com/user/image:latest')
+        # ...while in this case it is a hostname:
+        self.assertEqual(
+            tag_image_name('hostnames-cannot-have-undescores.example.com/user/image'),
+            'hostnames-cannot-have-undescores.example.com/user/image:latest')


### PR DESCRIPTION
Rocker currently does not work with custom registries, where the image name has a `hostname[:port]/` prefix. This is because of the way rocker constructs the names of customized images, by simply prepending the string `rocker_` and a suffix listing the active extension.

But a docker image reference has to match a [specific pattern](https://github.com/docker/distribution/blob/master/reference/reference.go). The names generated by rocker violated this syntax and caused errors for image names like `my.private.registry:5000/user/image:version1`, because `rocker_my.private.registry:5000/user/image:version1` is not a valid reference.

This pull request proposes a new way to tag the image names generated by rocker. Only the tag part is modified, while all other parts of the image reference are not modified. Because tags can only contain alphanumeric characters, dots and dashes, the separation character has been changed from `_` to `-`. So the "rockerized" image name of `tfoote/drone_demo` is `tfoote/drone_demo:rocker-latest-nvidia-pulse-x11-user`:

```
REPOSITORY                                        TAG                                   IMAGE ID            CREATED             SIZE
tfoote/drone_demo                                 rocker-latest-nvidia-pulse-x11-user   2be11d950222        4 minutes ago       10.5GB
tfoote/drone_demo                                 rocker--detection-latest              96831aeb6936        5 minutes ago       10.5GB
tfoote/drone_demo                                 latest                                09eb7cfa2fef        7 hours ago         10.5GB
tfoote/drone_demo                                 2019_Apr_17_1219                      9febf26b027d        4 months ago        7.24GB
```

Probably there is an easier way to implement the reference parser, but I have not found an existing Python module and a simple search and split at `:` would not cover all cases.

I ignored the fact that an image name could also have an optional digest part for now (`docker/image@sha256:xxxxxxxxx`).