### PR TITLE
Use exec system call instead of pexpect to fix terminal width in the container

### DIFF
--- a/src/rocker/core.py
+++ b/src/rocker/core.py
@@ -16,6 +16,7 @@
 
 from collections import OrderedDict
 import os
+import shlex
 import sys
 
 import pkg_resources
@@ -26,7 +27,6 @@ import tempfile
 import em
 
 import docker
-import pexpect
 
 class RockerExtension(object):
     """The base class for Rocker extension points"""
@@ -164,11 +164,8 @@ class DockerImageGenerator(object):
             try:
                 print("Executing command: ")
                 print(cmd)
-                p = pexpect.spawn(cmd)
-                p.interact()
-                p.terminate()
-                return p.exitstatus
-            except pexpect.ExceptionPexpect as ex:
+                os.execlp('docker', *shlex.split(cmd))
+            except OSError as ex:
                 print("Docker run failed\n", ex)
                 return 1
 


### PR DESCRIPTION
Was there a specific reason to use `pexpect` to interact for `docker run`? That caused issue with the detection of the terminal width (and probably other terminal settings) inside the running container, I assume because `WINCH` signals were not passed through.

Maybe there are other ways to fix that with `pexpect`, but my simple proposed solution is to use the `exec` system call and replace the Python process with `docker run`, because it is the last thing it is doing anyway.

It would be cleaner to collect the `docker run` arguments from extensions in an array instead of a string, that then needs to be decomposed according to shell syntax.