### PR TITLE
Fix sudo with user extension for some usernames

### DIFF
--- a/src/rocker/templates/user_snippet.Dockerfile.em
+++ b/src/rocker/templates/user_snippet.Dockerfile.em
@@ -9,7 +9,7 @@ RUN groupadd -g "@(gid)" "@name" \
  && useradd --uid "@(uid)" -s "@(shell)" -c "@(gecos)" -g "@(gid)" -d "@(dir)" "@(name)" \
  && echo "@(name):@(name)" | chpasswd \
  && adduser @(name) sudo \
- && echo "@(name) ALL=NOPASSWD: ALL" >> /etc/sudoers.d/@(name)
+ && echo "@(name) ALL=NOPASSWD: ALL" >> /etc/sudoers.d/rocker
 # Commands below run as the developer user
 USER @(name)
 @[else]@


### PR DESCRIPTION
Not all valid usernames are valid names for files in `/etc/sudoers.d/`.
We had the problem with a user that has a dot in his username.
The file `/etc/sudoers.d/firstname.lastname` was ignored by sudo.