### PR TITLE
Allow multiple --env arguments and add -e option

### DIFF
--- a/src/rocker/extensions.py
+++ b/src/rocker/extensions.py
@@ -166,7 +166,7 @@ class Environment(RockerExtension):
 
     @staticmethod
     def register_arguments(parser):
-        parser.add_argument('--env',
+        parser.add_argument('--env', '-e',
             metavar='NAME[=VALUE]',
             type=str,
             nargs='+',

--- a/src/rocker/extensions.py
+++ b/src/rocker/extensions.py
@@ -157,7 +157,9 @@ class Environment(RockerExtension):
 
     def get_docker_args(self, cli_args):
         args = ['']
-        for env in cli_args['env']:
+
+        envs = [ x for sublist in cli_args['env'] for x in sublist]
+        for env in envs:
             args.append('-e {0}'.format(quote(env)))
 
         return ' '.join(args)
@@ -168,4 +170,5 @@ class Environment(RockerExtension):
             metavar='NAME[=VALUE]',
             type=str,
             nargs='+',
+            action='append',
             help='set environment variables')

--- a/test/test_extension.py
+++ b/test/test_extension.py
@@ -214,8 +214,8 @@ class EnvExtensionTest(unittest.TestCase):
         p = env_plugin()
         self.assertTrue(plugin_load_parser_correctly(env_plugin))
         
-        mock_cliargs = {'env': ['ENVVARNAME=envvar_value', 'ENV2=val2']}
+        mock_cliargs = {'env': [['ENVVARNAME=envvar_value', 'ENV2=val2'], ['ENV3=val3']]}
 
         self.assertEqual(p.get_snippet(mock_cliargs), '')
         self.assertEqual(p.get_preamble(mock_cliargs), '')
-        self.assertEqual(p.get_docker_args(mock_cliargs), ' -e ENVVARNAME=envvar_value -e ENV2=val2')
+        self.assertEqual(p.get_docker_args(mock_cliargs), ' -e ENVVARNAME=envvar_value -e ENV2=val2 -e ENV3=val3')


### PR DESCRIPTION
This is a follow-up on #51.

It seems that [argparse](https://docs.python.org/3/library/argparse.html) does not handle the case where the same option with `nargs='+'` is specified more than once. Instead, it simply overwrites previous arguments.

This pull request fixes that behavior for compatibility with the behavior of `docker run --env VAR1 --env VAR2`. It also adds the `-e` argument as a short variant for `--env`.