### PR TITLE
Add sigwinch passthrough for xterm resizing

### DIFF
--- a/src/rocker/core.py
+++ b/src/rocker/core.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 from collections import OrderedDict
+import io
 import os
 import re
 import sys
@@ -31,8 +32,6 @@ import fcntl
 import signal
 import struct
 import termios
-
-SYS_STDOUT = sys.stdout
 
 
 class RockerExtension(object):
@@ -74,6 +73,7 @@ def get_docker_client():
         docker_client = docker.Client()
     return docker_client
 
+
 def docker_build(docker_client = None, output_callback = None, **kwargs):
     image_id = None
 
@@ -97,6 +97,42 @@ def docker_build(docker_client = None, output_callback = None, **kwargs):
     else:
         print("no more output and success not detected")
         return None
+
+
+class SIGWINCHPassthrough(object):
+    def __init__ (self, process):
+        self.process = process
+
+    def set_window_size(self):
+        s = struct.pack("HHHH", 0, 0, 0, 0)
+        try:
+            a = struct.unpack('hhhh', fcntl.ioctl(sys.stdout.fileno(),
+                termios.TIOCGWINSZ , s))
+        except (io.UnsupportedOperation, AttributeError) as ex:
+            # We're not interacting with a real stdout, don't do the resize
+            # This happens when we're in something like unit tests.
+            return
+        if not self.process.closed:
+            self.process.setwinsize(a[0],a[1])
+
+
+    def __enter__(self):
+        # Expected function prototype for signal handling
+        # ignoring unused arguments
+        def sigwinch_passthrough (sig, data):
+            self.set_window_size()
+    
+        signal.signal(signal.SIGWINCH, sigwinch_passthrough)
+ 
+        # Initially set the window size since it may not be default sized
+        self.set_window_size()
+        return self
+
+    # Clean up signal handler before returning.
+    def __exit__(self, exc_type, exc_value, traceback):
+        # This was causing hangs and resolved as referenced 
+        # here: https://github.com/pexpect/pexpect/issues/465
+        signal.signal(signal.SIGWINCH, signal.SIG_DFL)
 
 class DockerImageGenerator(object):
     def __init__(self, active_extensions, cliargs, base_image):
@@ -182,15 +218,9 @@ class DockerImageGenerator(object):
                 print("Executing command: ")
                 print(cmd)
                 p = pexpect.spawn(cmd)
-                def sigwinch_passthrough (sig, data):
-                    s = struct.pack("HHHH", 0, 0, 0, 0)
-                    a = struct.unpack('hhhh', fcntl.ioctl(SYS_STDOUT.fileno(),
-                        termios.TIOCGWINSZ , s))
-                    if not p.closed:
-                        p.setwinsize(a[0],a[1])
-                signal.signal(signal.SIGWINCH, sigwinch_passthrough)
-                p.interact()
-                p.terminate()
+                with SIGWINCHPassthrough(p):
+                    p.interact()
+                p.close(force=True)
                 return p.exitstatus
             except pexpect.ExceptionPexpect as ex:
                 print("Docker run failed\n", ex)

--- a/src/rocker/nvidia_extension.py
+++ b/src/rocker/nvidia_extension.py
@@ -28,6 +28,10 @@ from .extensions import name_to_argument
 from .core import get_docker_client
 from .core import RockerExtension
 
+def get_docker_version():
+    docker_version_raw = get_docker_client().version()['Version']
+    # Fix for version 17.09.0-ce
+    return Version(docker_version_raw.split('-')[0])
 
 class X11(RockerExtension):
     @staticmethod
@@ -111,10 +115,7 @@ class Nvidia(RockerExtension):
         return em.expand(snippet, self.get_environment_subs(cliargs))
 
     def get_docker_args(self, cliargs):
-        docker_version_raw = get_docker_client().version()['Version']
-        # Fix for version 17.09.0-ce
-        docker_version = Version(docker_version_raw.split('-')[0])
-        if docker_version >= Version("19.03"):
+        if get_docker_version() >= Version("19.03"):
             return "  --gpus all"
         return "  --runtime=nvidia"
 

--- a/test/test_nvidia.py
+++ b/test/test_nvidia.py
@@ -22,10 +22,12 @@ import pexpect
 
 
 from io import BytesIO as StringIO
+from packaging.version import Version
 
 from rocker.cli import DockerImageGenerator
 from rocker.cli import list_plugins
 from rocker.core import get_docker_client
+from rocker.nvidia_extension import get_docker_version
 from test_extension import plugin_load_parser_correctly
 
 
@@ -162,7 +164,10 @@ CMD glmark2 --validate
         #TODO(tfoote) restore with #37 self.assertIn(' -e XAUTHORITY=', docker_args)
         #TODO(tfoote) restore with #37 self.assertIn(' -v /tmp/.X11-unix:/tmp/.X11-unix ', docker_args)
         #TODO(tfoote) restore with #37 self.assertIn(' -v /etc/localtime:/etc/localtime:ro ', docker_args)
-        self.assertIn(' --runtime=nvidia', docker_args)
+        if get_docker_version() >= Version("19.03"):
+            self.assertIn(' --gpus all', docker_args)
+        else:
+            self.assertIn(' --runtime=nvidia', docker_args)
 
 
     def test_no_nvidia_glmark2(self):


### PR DESCRIPTION
This seem to help pass resize single events from xterm. Fixes: https://github.com/osrf/rocker/issues/7

The em package import is doing some odd stuff by overwriting sys.stdout, so I just stored it to a global variable before `em.expand()` gets called somewhere and changes it to an instance of `ProxyFile()`.

https://github.com/dirk-thomas/empy/blob/0df7f44312071b976d202a3f8a5fd2ce6aacd174/em.py#L2669

When setting byobu as from https://github.com/osrf/rocker/issues/7#issuecomment-527700022 , I still don't know why it still defaults to COLUMNS=80, LINES=23 for `rocker` and not `docker run`.