### PR TITLE
Do not build and run detect_os() twice in the nvidia extension

### DIFF
--- a/src/rocker/nvidia_extension.py
+++ b/src/rocker/nvidia_extension.py
@@ -92,16 +92,17 @@ class Nvidia(RockerExtension):
             self._env_subs['user_id'] = os.getuid()
             self._env_subs['username'] = getpass.getuser()
         
-            dist, ver, codename = detect_os(cliargs['base_image'])
-            self._env_subs['image_distro_id'] = dist
-            if self._env_subs['image_distro_id'] not in self.supported_distros:
-                print("WARNING distro id %s not supported by Nvidia supported " % self._env_subs['image_distro_id'], self.supported_distros)
-                sys.exit(1)
-            self._env_subs['image_distro_version'] = ver
-            if self._env_subs['image_distro_version'] not in self.supported_versions:
-                print("WARNING distro version %s not in supported list by Nvidia supported versions" % self._env_subs['image_distro_version'], self.supported_versions)
-                sys.exit(1)
-                # TODO(tfoote) add a standard mechanism for checking preconditions and disabling plugins
+        # non static elements test every time
+        dist, ver, codename = detect_os(cliargs['base_image'])
+        self._env_subs['image_distro_id'] = dist
+        if self._env_subs['image_distro_id'] not in self.supported_distros:
+            print("WARNING distro id %s not supported by Nvidia supported " % self._env_subs['image_distro_id'], self.supported_distros)
+            sys.exit(1)
+        self._env_subs['image_distro_version'] = ver
+        if self._env_subs['image_distro_version'] not in self.supported_versions:
+            print("WARNING distro version %s not in supported list by Nvidia supported versions" % self._env_subs['image_distro_version'], self.supported_versions)
+            sys.exit(1)
+            # TODO(tfoote) add a standard mechanism for checking preconditions and disabling plugins
 
         return self._env_subs
 

--- a/src/rocker/nvidia_extension.py
+++ b/src/rocker/nvidia_extension.py
@@ -87,20 +87,19 @@ class Nvidia(RockerExtension):
             self._env_subs['user_id'] = os.getuid()
             self._env_subs['username'] = getpass.getuser()
         
-        # non static elements test every time
-        if not build_detector_image():
-            print("ERROR: Failed to build image detector")
-            sys.exit(1)
-        dist, ver, codename = detect_os(cliargs['base_image'])
-        self._env_subs['image_distro_id'] = dist
-        if self._env_subs['image_distro_id'] not in self.supported_distros:
-            print("WARNING distro id %s not supported by Nvidia supported " % self._env_subs['image_distro_id'], self.supported_distros)
-            sys.exit(1)
-        self._env_subs['image_distro_version'] = ver
-        if self._env_subs['image_distro_version'] not in self.supported_versions:
-            print("WARNING distro version %s not in supported list by Nvidia supported versions" % self._env_subs['image_distro_version'], self.supported_versions)
-            sys.exit(1)
-            # TODO(tfoote) add a standard mechanism for checking preconditions and disabling plugins
+            if not build_detector_image():
+                print("ERROR: Failed to build image detector")
+                sys.exit(1)
+            dist, ver, codename = detect_os(cliargs['base_image'])
+            self._env_subs['image_distro_id'] = dist
+            if self._env_subs['image_distro_id'] not in self.supported_distros:
+                print("WARNING distro id %s not supported by Nvidia supported " % self._env_subs['image_distro_id'], self.supported_distros)
+                sys.exit(1)
+            self._env_subs['image_distro_version'] = ver
+            if self._env_subs['image_distro_version'] not in self.supported_versions:
+                print("WARNING distro version %s not in supported list by Nvidia supported versions" % self._env_subs['image_distro_version'], self.supported_versions)
+                sys.exit(1)
+                # TODO(tfoote) add a standard mechanism for checking preconditions and disabling plugins
 
         return self._env_subs
 

--- a/test/test_nvidia.py
+++ b/test/test_nvidia.py
@@ -24,8 +24,8 @@ import pexpect
 from io import BytesIO as StringIO
 from packaging.version import Version
 
-from rocker.cli import DockerImageGenerator
-from rocker.cli import list_plugins
+from rocker.core import DockerImageGenerator
+from rocker.core import list_plugins
 from rocker.core import get_docker_client
 from rocker.nvidia_extension import get_docker_version
 from test_extension import plugin_load_parser_correctly


### PR DESCRIPTION
The detector image was built twice, once for each call of `get_environment_subs()` from `get_preamble()` and `get_snippet()`. I do not see a reason why the base_image argument would change in between these two calls.