### PR TITLE
Do not tag intermediate images to allow for automatic pruning

### DIFF
--- a/src/rocker/cli.py
+++ b/src/rocker/cli.py
@@ -22,7 +22,6 @@ from .core import DockerImageGenerator
 from .core import list_plugins
 from .core import pull_image
 
-from .os_detector import build_detector_image
 from .os_detector import detect_os
 
 
@@ -71,9 +70,6 @@ def detect_image_os():
 
     args = parser.parse_args()    
 
-    if not build_detector_image():
-        print("Failed to build detector.")
-        return 1
     results = detect_os(args.image)
     print(results)
     if results:

--- a/src/rocker/core.py
+++ b/src/rocker/core.py
@@ -16,6 +16,7 @@
 
 from collections import OrderedDict
 import os
+import re
 import sys
 
 import pkg_resources
@@ -67,6 +68,30 @@ def get_docker_client():
         docker_client = docker.Client()
     return docker_client
 
+def docker_build(docker_client = None, output_callback = None, **kwargs):
+    image_id = None
+
+    if not docker_client:
+        docker_client = get_docker_client()
+    kwargs['decode'] = True
+    for line in docker_client.build(**kwargs):
+        output = line.get('stream', '').rstrip()
+        if not output:
+            # print("non stream data", line)
+            continue
+        if output_callback is not None:
+            output_callback(output)
+
+        match = re.match(r'Successfully built ([a-z0-9]{12})', output)
+        if match:
+            image_id = match[1]
+
+    if image_id:
+        return image_id
+    else:
+        print("no more output and success not detected")
+        return None
+
 class DockerImageGenerator(object):
     def __init__(self, active_extensions, cliargs, base_image):
         self.built = False
@@ -75,12 +100,8 @@ class DockerImageGenerator(object):
         self.active_extensions = active_extensions
 
         self.dockerfile = generate_dockerfile(active_extensions, self.cliargs, base_image)
-        # print(df)
-        self.image_name = "rocker_" + base_image
-        if self.active_extensions:
-            self.image_name += "_%s" % '_'.join([e.name for e in active_extensions])
+        self.image_id = None
 
-    
     def build(self, **kwargs):
         with tempfile.TemporaryDirectory() as td:
             df = os.path.join(td, 'Dockerfile')
@@ -93,31 +114,21 @@ class DockerImageGenerator(object):
             arguments = {}
             arguments['path'] = td
             arguments['rm'] = True
-            arguments['decode'] = True
             arguments['nocache'] = kwargs.get('nocache', False)
-            arguments['tag'] = self.image_name
             print("Building docker file with arguments: ", arguments)
             try:
-                docker_client = get_docker_client()
-                success_detected = False
-                for line in docker_client.build(**arguments):
-                    output = line.get('stream', '').rstrip()
-                    if not output:
-                        # print("non stream data", line)
-                        continue
-                    print("building > %s" % output)
-                    if output.startswith("Successfully tagged") and self.image_name in output:
-                        success_detected = True
-                if success_detected:
-                        self.built = True
-                        return 0
+                self.image_id = docker_build(
+                    **arguments,
+                    output_callback=lambda output: print("building > %s" % output)
+                )
+                if self.image_id:
+                    self.built = True
+                    return 0
                 else:
-                    print("no more output and success not detected")
                     return 2
- 
+
             except docker.errors.APIError as ex:
                 print("Docker build failed\n", ex)
-                print(ex.output)
                 return 1
 
     def run(self, command='', **kwargs):
@@ -150,7 +161,7 @@ class DockerImageGenerator(object):
         for e in self.active_extensions:
             docker_args += e.get_docker_args(self.cliargs)
 
-        image = self.image_name
+        image = self.image_id
         cmd="docker run -it \
   --rm \
   %(docker_args)s \

--- a/src/rocker/core.py
+++ b/src/rocker/core.py
@@ -84,7 +84,7 @@ def docker_build(docker_client = None, output_callback = None, **kwargs):
 
         match = re.match(r'Successfully built ([a-z0-9]{12})', output)
         if match:
-            image_id = match[1]
+            image_id = match.group(1)
 
     if image_id:
         return image_id

--- a/src/rocker/nvidia_extension.py
+++ b/src/rocker/nvidia_extension.py
@@ -21,7 +21,6 @@ from pathlib import Path
 import subprocess
 import sys
 
-from .os_detector import build_detector_image
 from .os_detector import detect_os
 
 from .extensions import name_to_argument
@@ -88,9 +87,6 @@ class Nvidia(RockerExtension):
             self._env_subs['username'] = getpass.getuser()
         
         # non static elements test every time
-        if not build_detector_image():
-            print("ERROR: Failed to build image detector")
-            sys.exit(1)
         dist, ver, codename = detect_os(cliargs['base_image'])
         self._env_subs['image_distro_id'] = dist
         if self._env_subs['image_distro_id'] not in self.supported_distros:

--- a/test/test_os_detect.py
+++ b/test/test_os_detect.py
@@ -19,14 +19,9 @@ import docker
 import unittest
 
 
-from rocker.os_detector import build_detector_image
 from rocker.os_detector import detect_os
 
 class RockerOSDetectorTest(unittest.TestCase):
-
-    @classmethod
-    def setUpClass(self):
-        build_detector_image()
 
     def test_ubuntu(self):
         result = detect_os("ubuntu:xenial")


### PR DESCRIPTION
Docker images need to be cleaned up from time to time to not fill up the file system with obsolete images. This is typically done by running `docker image prune` or `docker system prune`. This command does not remove tagged images by default, unless called with `-a`. The latter is typically not what you want, because it also removes all the images pulled from Docker Hub or other remote registries.

In fact, there is no need for Rocker to assign tags to the intermediate images. The image IDs work just fine.

This patch also renders https://github.com/osrf/rocker/pull/52 obsolete.