### PR TITLE
Support `--nvidia` option on docker >= 19.03

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ from setuptools import setup
 install_requires = [
     'empy',
     'pexpect',
+    'packaging',
 ]
 
 # docker API used to be in a package called `docker-py` before the 2.0 release

--- a/src/rocker/nvidia_extension.py
+++ b/src/rocker/nvidia_extension.py
@@ -16,6 +16,7 @@ import grp
 import os
 import em
 import getpass
+from packaging.version import Version
 import pkgutil
 from pathlib import Path
 import subprocess
@@ -25,6 +26,7 @@ from .os_detector import build_detector_image
 from .os_detector import detect_os
 
 from .extensions import name_to_argument
+from .core import get_docker_client
 from .core import RockerExtension
 
 
@@ -113,8 +115,10 @@ class Nvidia(RockerExtension):
         return em.expand(snippet, self.get_environment_subs(cliargs))
 
     def get_docker_args(self, cliargs):
-        return "  --runtime=nvidia \
-  --security-opt seccomp=unconfined" % locals()
+        docker_version = Version(get_docker_client().version()['Version'])
+        if docker_version >= Version("19.03"):
+            return "  --gpus all"
+        return "  --runtime=nvidia"
 
     @staticmethod
     def register_arguments(parser):

--- a/src/rocker/nvidia_extension.py
+++ b/src/rocker/nvidia_extension.py
@@ -115,7 +115,9 @@ class Nvidia(RockerExtension):
         return em.expand(snippet, self.get_environment_subs(cliargs))
 
     def get_docker_args(self, cliargs):
-        docker_version = Version(get_docker_client().version()['Version'])
+        docker_version_raw = get_docker_client().version()['Version']
+        # Fix for version 17.09.0-ce
+        docker_version = Version(docker_version_raw.split('-')[0])
         if docker_version >= Version("19.03"):
             return "  --gpus all"
         return "  --runtime=nvidia"

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,7 +1,7 @@
 [rocker]
 Debian-Version: 100
 No-Python2:
-Depends3: python3-docker, python3-empy, python3-pexpect
+Depends3: python3-docker, python3-empy, python3-pexpect, python3-packaging
 Conflicts3: python-rocker
 Suite: xenial yakkety zesty artful bionic cosmic disco eoan stretch buster
 X-Python3-Version: >= 3.2

--- a/test/test_nvidia.py
+++ b/test/test_nvidia.py
@@ -162,8 +162,7 @@ CMD glmark2 --validate
         #TODO(tfoote) restore with #37 self.assertIn(' -e XAUTHORITY=', docker_args)
         #TODO(tfoote) restore with #37 self.assertIn(' -v /tmp/.X11-unix:/tmp/.X11-unix ', docker_args)
         #TODO(tfoote) restore with #37 self.assertIn(' -v /etc/localtime:/etc/localtime:ro ', docker_args)
-        self.assertIn(' --runtime=nvidia ', docker_args)
-        self.assertIn(' --security-opt seccomp=unconfined', docker_args)
+        self.assertIn(' --runtime=nvidia', docker_args)
 
 
     def test_no_nvidia_glmark2(self):


### PR DESCRIPTION
Using more recent versions of docker the `--nvidia` option causes rocker to error with a message about the runtime being unsuported.

```
Executing command: 
docker run -it   --rm     --runtime=nvidia   --security-opt seccomp=unconfined --cap-add SYS_PTRACE -v /home/sloretz/workspaces/darknet:/home/sloretz/workspaces/darknet "--ipc=host"  -e DISPLAY -e TERM   -e QT_X11_NO_MITSHM=1   -e XAUTHORITY=/tmp/.docker.xauth -v /tmp/.docker.xauth:/tmp/.docker.xauth   -v /tmp/.X11-unix:/tmp/.X11-unix   -v /etc/localtime:/etc/localtime:ro    rocker_ros2-bionic_nvidia_oyr_cap_add_oyr_colcon_oyr_mount_oyr_run_arg_x11_user 
/usr/bin/docker: Error response from daemon: Unknown runtime specified nvidia.
See '/usr/bin/docker run --help'.
```

This PR use `--gpus all` on more recent versions of docker (following [nvidia-docker instructions](https://github.com/NVIDIA/nvidia-docker/tree/0f10e4f8c53a14142557ca3ba3452120b2b53a60#quickstart)), and uses `--runtime=nvidia` on older versions. It also removes `--security-opt` since that's [unrelated to using nvidia gpus](https://docs.docker.com/engine/security/seccomp/).

The change adds a dependency on the [packaging](https://pypi.org/project/packaging/) module available on Debian platforms as [python3-packaging](https://packages.debian.org/stretch/python3-packaging).
