### PR TITLE
Work around glibc issue for os detection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ python:
   - "3.5"
   - "3.6"
 
-
 services:
   - docker
   - xvfb
@@ -16,6 +15,6 @@ install:
 
 # Nvidia not available on travis
 script:
-  - xvfb-run nosetests -v --with-coverage --cover-package rocker --exclude test_nvidia_glmark2
+  - nosetests -v --with-coverage --cover-package rocker --exclude test_nvidia_glmark2
 after_success:
   - codecov

--- a/src/rocker/cli.py
+++ b/src/rocker/cli.py
@@ -70,10 +70,12 @@ def main():
 def detect_image_os():
     parser = argparse.ArgumentParser(description='Detect the os in an image')
     parser.add_argument('image')
+    parser.add_argument('--verbose', action='store_true',
+        help='Display verbose output of the process')
 
     args = parser.parse_args()    
 
-    results = detect_os(args.image)
+    results = detect_os(args.image, print if args.verbose else None)
     print(results)
     if results:
         return 0

--- a/src/rocker/os_detector.py
+++ b/src/rocker/os_detector.py
@@ -21,7 +21,11 @@ from .core import docker_build
 
 
 DETECTION_TEMPLATE="""
-FROM python:3 as detector
+FROM python:3-stretch as detector
+# Force the older version of debian for detector.
+# GLIBC is forwards compatible but not necessarily backwards compatible for pyinstaller
+# https://github.com/pyinstaller/pyinstaller/wiki/FAQ#gnulinux
+# StaticX is supposed to take care of this but there appears to be an issue when using subprocess
 
 RUN mkdir -p /tmp/distrovenv
 RUN python3 -m venv /tmp/distrovenv

--- a/test/test_os_detect.py
+++ b/test/test_os_detect.py
@@ -32,6 +32,11 @@ class RockerOSDetectorTest(unittest.TestCase):
         self.assertEqual(result[0], 'Ubuntu')
         self.assertEqual(result[1], '18.04')
 
+        # Cover verbose codepath
+        result = detect_os("ubuntu:bionic", output_callback=print)
+        self.assertEqual(result[0], 'Ubuntu')
+        self.assertEqual(result[1], '18.04')
+
     def test_fedora(self):
         result = detect_os("fedora:29")
         self.assertEqual(result[0], 'Fedora')


### PR DESCRIPTION
Diagnosted from: https://github.com/osrf/car_demo/issues/70

There appears to be an issue with using subprocess when on ros:kinetic that doesn't appear when detecting on ubuntu:xenial due to the different detection code path. This will work around it for now. I think there's something to file upstream with staticx too.