### PR TITLE
Create a home directory if one does not exist for the user

### DIFF
--- a/src/rocker/extensions.py
+++ b/src/rocker/extensions.py
@@ -135,7 +135,9 @@ class User(RockerExtension):
 
     def get_snippet(self, cliargs):
         snippet = pkgutil.get_data('rocker', 'templates/%s_snippet.Dockerfile.em' % self.name).decode('utf-8')
-        return em.expand(snippet, self.get_environment_subs())
+        substitutions = self.get_environment_subs()
+        substitutions['home_extension_active'] = True if 'home' in cliargs and cliargs['home'] else False
+        return em.expand(snippet, substitutions)
 
     @staticmethod
     def register_arguments(parser):

--- a/src/rocker/templates/user_snippet.Dockerfile.em
+++ b/src/rocker/templates/user_snippet.Dockerfile.em
@@ -10,6 +10,10 @@ RUN groupadd -g "@(gid)" "@name" \
  && echo "@(name):@(name)" | chpasswd \
  && adduser @(name) sudo \
  && echo "@(name) ALL=NOPASSWD: ALL" >> /etc/sudoers.d/rocker
+@[if not home_extension_active ]@
+# Making sure a home directory exists if we haven't mounted the user's home directory explicitly
+RUN mkhomedir_helper @(name)
+@[end if]@
 # Commands below run as the developer user
 USER @(name)
 @[else]@

--- a/test/test_extension.py
+++ b/test/test_extension.py
@@ -117,6 +117,11 @@ class UserExtensionTest(unittest.TestCase):
         self.assertEqual(p.get_preamble(mock_cliargs), '')
         self.assertEqual(p.get_docker_args(mock_cliargs), '')
 
+        self.assertTrue('mkhomedir_helper' in p.get_snippet(mock_cliargs))
+        home_active_cliargs = mock_cliargs
+        home_active_cliargs['home'] = True
+        self.assertFalse('mkhomedir_helper' in p.get_snippet(home_active_cliargs))
+
 
 class PulseExtensionTest(unittest.TestCase):
 


### PR DESCRIPTION
This will avoid many errors.
It will not try if the user's home directory is to be mounted by the home extension.
The tool will also not touch any preexisting directory so if it's mounted any other way it should be safe too.

Fixes #42
