### PR TITLE
print user-friendly message on os detection failure

### DIFF
--- a/src/rocker/nvidia_extension.py
+++ b/src/rocker/nvidia_extension.py
@@ -93,7 +93,7 @@ class Nvidia(RockerExtension):
             self._env_subs['username'] = getpass.getuser()
         
         # non static elements test every time
-        detected_os = detect_os(cliargs['base_image'])
+        detected_os = detect_os(cliargs['base_image'], print)
         if detected_os is None:
             print("WARNING unable to detect os for base image '%s', maybe the base image does not exist" % cliargs['base_image'])
             sys.exit(1)

--- a/src/rocker/nvidia_extension.py
+++ b/src/rocker/nvidia_extension.py
@@ -93,7 +93,12 @@ class Nvidia(RockerExtension):
             self._env_subs['username'] = getpass.getuser()
         
         # non static elements test every time
-        dist, ver, codename = detect_os(cliargs['base_image'])
+        detected_os = detect_os(cliargs['base_image'])
+        if detected_os is None:
+            print("WARNING unable to detect os for base image '%s', maybe the base image does not exist" % cliargs['base_image'])
+            sys.exit(1)
+        dist, ver, codename = detected_os
+
         self._env_subs['image_distro_id'] = dist
         if self._env_subs['image_distro_id'] not in self.supported_distros:
             print("WARNING distro id %s not supported by Nvidia supported " % self._env_subs['image_distro_id'], self.supported_distros)

--- a/src/rocker/os_detector.py
+++ b/src/rocker/os_detector.py
@@ -54,7 +54,8 @@ def detect_os(image_name, output_callback=None):
     iof = StringIO((DETECTION_TEMPLATE % locals()).encode())
     image_id = docker_build(fileobj = iof, output_callback=output_callback)
     if not image_id:
-        print('Failed to build detector image')
+        if output_callback:
+            output_callback('Failed to build detector image')
         return None
 
     cmd="docker run -it --rm %s" % image_id

--- a/test/test_nvidia.py
+++ b/test/test_nvidia.py
@@ -184,3 +184,27 @@ CMD glmark2 --validate
             dig = DockerImageGenerator(active_extensions, {}, tag)
             self.assertEqual(dig.build(), 0)
             self.assertEqual(dig.run(), 0)
+
+    def test_nvidia_env_subs(self):
+        plugins = list_plugins()
+        nvidia_plugin = plugins['nvidia']
+
+        p = nvidia_plugin()
+
+        # base image doesn't exist
+        mock_cliargs = {'base_image': 'ros:does-not-exist'}
+        with self.assertRaises(SystemExit) as cm:
+            p.get_environment_subs(mock_cliargs)
+        self.assertEqual(cm.exception.code, 1)
+
+        # unsupported version
+        mock_cliargs = {'base_image': 'ubuntu:17:04'}
+        with self.assertRaises(SystemExit) as cm:
+            p.get_environment_subs(mock_cliargs)
+        self.assertEqual(cm.exception.code, 1)
+
+        # unsupported os
+        mock_cliargs = {'base_image': 'debian'}
+        with self.assertRaises(SystemExit) as cm:
+            p.get_environment_subs(mock_cliargs)
+        self.assertEqual(cm.exception.code, 1)


### PR DESCRIPTION
Current behavior in the case of the passed base image not existing can be confusing.

Current behavior:
```
$ rocker --x11 --nvidia ros:eloquent-desktop
Plugins found: ['dev_helpers', 'env', 'git', 'home', 'nvidia', 'pulse', 'ssh', 'user', 'x11']
Active extensions ['nvidia', 'x11']
no more output and success not detected
Failed to build detector image
Traceback (most recent call last):
  File "/home/mikatchou/.local/bin/rocker", line 11, in <module>
    load_entry_point('rocker==0.1.10', 'console_scripts', 'rocker')()
  File "/home/mikatchou/.local/lib/python3.6/site-packages/rocker/cli.py", line 60, in main
    dig = DockerImageGenerator(active_extensions, args_dict, base_image)
  File "/home/mikatchou/.local/lib/python3.6/site-packages/rocker/core.py", line 145, in __init__
    self.dockerfile = generate_dockerfile(active_extensions, self.cliargs, base_image)
  File "/home/mikatchou/.local/lib/python3.6/site-packages/rocker/core.py", line 235, in generate_dockerfile
    dockerfile_str += el.get_preamble(args_dict) + '\n'
  File "/home/mikatchou/.local/lib/python3.6/site-packages/rocker/nvidia_extension.py", line 111, in get_preamble
    return em.expand(preamble, self.get_environment_subs(cliargs))
  File "/home/mikatchou/.local/lib/python3.6/site-packages/rocker/nvidia_extension.py", line 96, in get_environment_subs
    dist, ver, codename = detect_os(cliargs['base_image'])
TypeError: 'NoneType' object is not iterable
```

With this PR:
```
$ rocker --x11 --nvidia ros:eloquent-desktop
Plugins found: ['dev_helpers', 'env', 'git', 'home', 'nvidia', 'pulse', 'ssh', 'user', 'x11']
Active extensions ['nvidia', 'x11']
no more output and success not detected
Failed to build detector image
WARNING unable to detect os for base image 'ros:eloquent-desktop', maybe the base image does not exist
```