### PR TITLE
user extension: skip apt-get call if sudo is already installed

### DIFF
--- a/src/rocker/templates/user_snippet.Dockerfile.em
+++ b/src/rocker/templates/user_snippet.Dockerfile.em
@@ -1,8 +1,9 @@
 # make sure sudo is installed to be able to give user sudo access in docker
-RUN apt-get update \
- && apt-get install -y \
-    sudo \
- && apt-get clean
+RUN if ! command -v sudo >/dev/null; then \
+      apt-get update \
+      && apt-get install -y sudo \
+      && apt-get clean; \
+    fi
 
 @[if name != 'root']@
 RUN groupadd -g "@(gid)" "@name" \


### PR DESCRIPTION
This saves some time on startup if `sudo` is already installed in the docker image.