### PR TITLE
Add new argument --env-file

### DIFF
--- a/src/rocker/cli.py
+++ b/src/rocker/cli.py
@@ -47,8 +47,8 @@ def main():
     args = parser.parse_args()
     args_dict = vars(args)
     
-    active_extensions = [e() for e in plugins.values() if args_dict.get(e.get_name())]
-    # Force user to end if present otherwise it will 
+    active_extensions = [e() for e in plugins.values() if e.is_active(args_dict)]
+    # Force user to end if present otherwise it will break other extensions
     active_extensions.sort(key=lambda e:e.get_name().startswith('user'))
     print("Active extensions %s" % [e.get_name() for e in active_extensions])
 

--- a/src/rocker/core.py
+++ b/src/rocker/core.py
@@ -54,11 +54,16 @@ class RockerExtension(object):
     def get_snippet(self, cliargs):
         return ''
 
-    def get_name(self, cliargs):
+    @staticmethod
+    def get_name():
         raise NotImplementedError
     
     def get_docker_args(self, cliargs):
         return ''
+
+    @classmethod
+    def is_active(self, cliargs):
+        return bool(cliargs.get(self.get_name()))
 
     @staticmethod
     def register_arguments(parser):

--- a/src/rocker/extensions.py
+++ b/src/rocker/extensions.py
@@ -143,7 +143,7 @@ class User(RockerExtension):
     def register_arguments(parser):
         parser.add_argument(name_to_argument(User.get_name()),
             action='store_true',
-            help="mount the users home directory")
+            help="run the container with the uid/gid of the host user")
 
 
 class Environment(RockerExtension):
@@ -160,11 +160,23 @@ class Environment(RockerExtension):
     def get_docker_args(self, cli_args):
         args = ['']
 
-        envs = [ x for sublist in cli_args['env'] for x in sublist]
-        for env in envs:
-            args.append('-e {0}'.format(quote(env)))
+        env_files = cli_args['env_file']
+        if env_files:
+            env_files = [ x for sublist in env_files for x in sublist ]
+            for env_file in env_files:
+                args.append('--env-file {0}'.format(quote(env_file)))
+
+        envs = cli_args['env']
+        if envs:
+            envs = [ x for sublist in envs for x in sublist ]
+            for env in envs:
+                args.append('-e {0}'.format(quote(env)))
 
         return ' '.join(args)
+
+    @classmethod
+    def is_active(self, cli_args):
+        return cli_args.get('env') or cli_args.get('env_file')
 
     @staticmethod
     def register_arguments(parser):
@@ -174,3 +186,8 @@ class Environment(RockerExtension):
             nargs='+',
             action='append',
             help='set environment variables')
+        parser.add_argument('--env-file',
+            type=str,
+            nargs='+',
+            action='append',
+            help='read in a file of environment variables')


### PR DESCRIPTION
Adds support for the `--env-file` argument, in the same way as `docker run`.
See https://docs.docker.com/engine/reference/commandline/run/#set-environment-variables--e---env---env-file.

I had to introduce a new class method `is_active(self, cliargs)` to delegate the check whether an extension is active or not to the plugin code itself. Otherwise it would not be possible that one extension supports multiple command-line arguments.