### PR TITLE
Fix documentation for User extension

### DIFF
--- a/src/rocker/extensions.py
+++ b/src/rocker/extensions.py
@@ -143,7 +143,7 @@ class User(RockerExtension):
     def register_arguments(parser):
         parser.add_argument(name_to_argument(User.get_name()),
             action='store_true',
-            help="mount the users home directory")
+            help="mount the current user's id and run as that user")
 
 
 class Environment(RockerExtension):


### PR DESCRIPTION
It looks like it was just copy-pasted from the `HomeDir` extension, and was confusing at first when I did `rocker -h`

Signed-off-by: Emerson Knapp <emerson.b.knapp@gmail.com>