### PR TITLE
Do not pull all available tags with --pull

### DIFF
--- a/src/rocker/cli.py
+++ b/src/rocker/cli.py
@@ -20,7 +20,6 @@ import sys
 
 from .core import DockerImageGenerator
 from .core import get_rocker_version
-from .core import pull_image
 from .core import RockerExtensionManager
 
 from .os_detector import detect_os
@@ -57,9 +56,6 @@ def main():
     print("Active extensions %s" % [e.get_name() for e in active_extensions])
 
     base_image = args.image
-
-    if args.pull:
-        pull_image(base_image)
 
     dig = DockerImageGenerator(active_extensions, args_dict, base_image)
     exit_code = dig.build(**vars(args))

--- a/src/rocker/core.py
+++ b/src/rocker/core.py
@@ -197,6 +197,7 @@ class DockerImageGenerator(object):
             arguments['path'] = td
             arguments['rm'] = True
             arguments['nocache'] = kwargs.get('nocache', False)
+            arguments['pull'] = kwargs.get('pull', False)
             print("Building docker file with arguments: ", arguments)
             try:
                 self.image_id = docker_build(
@@ -299,18 +300,6 @@ def list_plugins(extension_point='rocker.extensions'):
     plugin_names = list(unordered_plugins.keys())
     plugin_names.sort()
     return OrderedDict([(k, unordered_plugins[k]) for k in plugin_names])
-
-
-def pull_image(image_name):
-    docker_client = get_docker_client()
-    try:
-        print("Pulling image %s" % image_name)
-        for line in docker_client.pull(image_name, stream=True):
-            print(line)
-        return True
-    except docker.errors.APIError as ex:
-        print('Pull of %s failed: %s' % (image_name, ex))
-        return False
 
 
 def get_rocker_version():

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -23,7 +23,6 @@ from itertools import chain
 
 from rocker.core import DockerImageGenerator
 from rocker.core import list_plugins
-from rocker.core import pull_image
 from rocker.core import get_docker_client
 from rocker.core import get_rocker_version
 from rocker.core import RockerExtensionManager
@@ -56,21 +55,6 @@ class RockerCoreTest(unittest.TestCase):
         for p in parts:
             # Check that it can be cast to an int
             i = int(p)
-
-    def test_pull_image(self):
-        TEST_IMAGE='alpine:latest'
-        docker_client = get_docker_client()
-
-        l = docker_client.images()
-        tags = set(chain.from_iterable([i['RepoTags'] for i in l if i['RepoTags']]))
-        print(tags)
-        if TEST_IMAGE in tags:
-            docker_client.remove_image(TEST_IMAGE)
-            print('removed image %s' % TEST_IMAGE)
-        self.assertTrue(pull_image(TEST_IMAGE))
-
-    def test_failed_pull_image(self):
-        self.assertFalse(pull_image("osrf/ros:does_not_exist"))
 
     def test_run_before_build(self):
         dig = DockerImageGenerator([], {}, 'ubuntu:bionic')


### PR DESCRIPTION
`rocker --pull <image>` without a tag pulls all available tags for that image, and hence can fill the disk quickly.

The reason is that the underlying [`docker_client.pull(image,tag=None)`](https://docker-py.readthedocs.io/en/latest/images.html#docker.models.images.ImageCollection.pull) pulls all available tags if no specific tag is specfied:

> If no tag was specified, the method will return a list of Image objects belonging to this repository.

So the removed method `rocker.core.pull_image(image_name)` would have to decompose the URL given at the command line, and either pass the tag separately, or append `:latest` to `image_name` if no other tag was specified.

This patch removes the broken method completely. It is not needed, because the pull flag can simply be forwarded to the [`docker_client.build()`](https://docker-py.readthedocs.io/en/2.5.1/images.html#docker.models.images.ImageCollection.build) command, at least for [docker-py version 2.5.1](https://docker-py.readthedocs.io/en/2.5.1/images.html#docker.models.images.ImageCollection.build) provided by [Ubuntu Bionic](https://packages.ubuntu.com/bionic/python-docker) and [version 1.8.0](https://docker-py.readthedocs.io/en/1.8.0/api/#build) provided by [Ubuntu Xenial](https://packages.ubuntu.com/xenial/python-docker).

Verified with:
```sh
$ docker pull ubuntu:bionic
bionic: Pulling from library/ubuntu
171857c49d0f: Already exists 
419640447d26: Already exists 
61e52f862619: Already exists 
Digest: sha256:646942475da61b4ce9cc5b3fadb42642ea90e5d0de46111458e100ff2c7031e6
Status: Downloaded newer image for ubuntu:bionic
docker.io/library/ubuntu:bionic
$ docker tag ubuntu:bionic ubuntu:latest
$ rocker ubuntu    # expectation: same as ubuntu:latest
[...]
Building docker file with arguments:  {'path': '/tmp/tmppa0oykh2', 'rm': True, 'nocache': False, 'pull': False}
[...]
root@a95d93f22ee6:/# cat /etc/lsb-release 
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=18.04
DISTRIB_CODENAME=bionic
DISTRIB_DESCRIPTION="Ubuntu 18.04.5 LTS"
root@a95d93f22ee6:/# exit
exit
```
So the version tagged as `ubuntu:latest` is actually `ubuntu:bionic`. `rocker` did not attempt to pull a newer version.

`--pull` still has the desired effect and the docker daemon pulls the image during the build:
```sh
$ rocker --pull ubuntu    # expectation: same as ubuntu:latest
[...]
Building docker file with arguments:  {'path': '/tmp/tmp8zlicrod', 'rm': True, 'nocache': False, 'pull': True}
[...]
root@475275ae66cc:/# cat /etc/lsb-release 
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=20.04
DISTRIB_CODENAME=focal
DISTRIB_DESCRIPTION="Ubuntu 20.04.1 LTS"
root@475275ae66cc:/# exit
exit
```

Without this patch, the second invocation `rocker --pull ubuntu` would take very long and pull all available tags.