### PR TITLE
Choose a unique name for the temporary xauth file created by the X11 extension

### DIFF
--- a/src/rocker/nvidia_extension.py
+++ b/src/rocker/nvidia_extension.py
@@ -16,6 +16,7 @@ import grp
 import os
 import em
 import getpass
+import tempfile
 from packaging.version import Version
 import pkgutil
 from pathlib import Path
@@ -41,7 +42,10 @@ class X11(RockerExtension):
     def __init__(self):
         self.name = X11.get_name()
         self._env_subs = None
-        self.xauth = '/tmp/.docker.xauth'
+        _, self.xauth = tempfile.mkstemp(prefix='.docker', suffix='.xauth')
+
+    def __del__(self):
+        os.unlink(self.xauth)
 
     def get_docker_args(self, cliargs):
         xauth = self.xauth


### PR DESCRIPTION
Fixes #102:

> The [`--x11` extension](https://github.com/osrf/rocker/blob/b4a736bfa98c409c5565ec3f77bc58673db7cbd0/src/rocker/nvidia_extension.py#L36) fails to run `xauth` on the host if the hard-coded `/tmp/.docker.xauth` already exists and has been created by another user (permissions are 0600):
> 
> ```shell
> xauth:  timeout in locking authority file /tmp/.docker.xauth
> Failed setting up XAuthority with command xauth nlist localhost:11.0 | sed -e 's/^..../ffff/' | xauth -f /tmp/.docker.xauth nmerge -
> Failed to precondition for extension [x11] with error: Command 'xauth nlist localhost:11.0 | sed -e 's/^..../ffff/' | xauth -f /tmp/.docker.xauth nmerge -' returned non-zero exit status 1.
> deactivating
> ```
> 
> I suggest to create the file with [tempfile.mkstemp](https://docs.python.org/3.10/library/tempfile.html#tempfile.mkstemp) instead on the host, such that each rocker invocation is independent of previous runs:
> 
> https://github.com/osrf/rocker/blob/b4a736bfa98c409c5565ec3f77bc58673db7cbd0/src/rocker/nvidia_extension.py#L44

