### PR TITLE
Allow regular expression device strings

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ install_requires = [
     'empy',
     'pexpect',
     'packaging',
+    'sre_yield',
 ]
 
 # docker API used to be in a package called `docker-py` before the 2.0 release

--- a/src/rocker/core.py
+++ b/src/rocker/core.py
@@ -248,14 +248,6 @@ class DockerImageGenerator(object):
 
         docker_args = ''
 
-        devices = kwargs.get('devices', None)
-        if devices:
-            for device in devices:
-                if not os.path.exists(device):
-                    print("ERROR device %s doesn't exist. Skipping" % device)
-                    continue
-                docker_args += ' --device %s ' % device
-
         for e in self.active_extensions:
             docker_args += e.get_docker_args(self.cliargs)
 

--- a/src/rocker/extensions.py
+++ b/src/rocker/extensions.py
@@ -26,6 +26,8 @@ import sys
 
 from .core import get_docker_client
 
+from sre_yield import AllStrings
+
 
 def name_to_argument(name):
     return '--%s' % name.replace('_', '-')
@@ -46,6 +48,8 @@ class Devices(RockerExtension):
     def get_docker_args(self, cliargs):
         args = ''
         devices = cliargs.get('devices', None)
+        if devices:
+            devices = [device for device_re in devices for device in AllStrings(device_re)]
         for device in devices:
             if not os.path.exists(device):
                 print("ERROR device %s doesn't exist. Skipping" % device)

--- a/test/test_extension.py
+++ b/test/test_extension.py
@@ -82,6 +82,13 @@ class DevicesExtensionTest(unittest.TestCase):
         args = p.get_docker_args(mock_cliargs)
         self.assertFalse('--device' in args)
 
+        # Check case for regular expression device
+        mock_cliargs = {'devices': ['/dev/(random|null)']}
+        self.assertEqual(p.get_snippet(mock_cliargs), '')
+        self.assertEqual(p.get_preamble(mock_cliargs), '')
+        args = p.get_docker_args(mock_cliargs)
+        self.assertTrue('--device /dev/random' in args and '--device /dev/null' in args)
+
 
 class HomeExtensionTest(unittest.TestCase):
 


### PR DESCRIPTION
It might be nice to allow regular expressions when specifying devices, including all values that match the regular expression. I do not know if such a feature is within the scope of this package, but I have found it to be very useful with multiple devices.

For example, instead of writing this:

`rocker test_image --devices /dev/dri/card0 /dev/ttyACM0 /dev/ttyACM1 /dev/ttyACM2 /dev/ttyACM3 /dev/ttyACM4 /dev/ttyACM5`

You could instead write something like this:

`rocker test_image --devices /dev/dri/card0 /dev/ttyACM[0-5]`

Or even something like this to connect 16 devices:

`rocker test_image --devices /dev/dri/card0 "/dev/ttyACM([0-9]|1[0-5])"`

The code in this pull request seems to work fine, but it is just a suggestion for one way it could be implemented. It uses sre_yield, which adds another dependency unfortunately, but that makes the regular expression matching easy. There may be a much cleaner location for the matching of the regular expression.

I removed the block of code that added devices to the docker_args in core.py. It seemed redundant when using the devices extension. Perhaps that second check is necessary after all if the devices extension is optional, but then it should probably only be performed if the devices extension is not used.

Other arguments, like volumes, may benefit from a regular expression expansion also, perhaps the expansion could happen in a more centralized location so it acts on every argument where it makes sense without needing to be repeated.