### PR TITLE
Remove redundant device additions to docker_args

### DIFF
--- a/src/rocker/core.py
+++ b/src/rocker/core.py
@@ -248,14 +248,6 @@ class DockerImageGenerator(object):
 
         docker_args = ''
 
-        devices = kwargs.get('devices', None)
-        if devices:
-            for device in devices:
-                if not os.path.exists(device):
-                    print("ERROR device %s doesn't exist. Skipping" % device)
-                    continue
-                docker_args += ' --device %s ' % device
-
         for e in self.active_extensions:
             docker_args += e.get_docker_args(self.cliargs)
 


### PR DESCRIPTION
Devices get added to docker_args twice when the devices extension is used. Devices are added to docker_args in core.py and then again by the active extension.

Removing this code may cause unintended behavior for the odd situation of someone disabling the devices extension while still supplying device arguments. If the intended behavior for that case is to still add the devices to the docker_args, even though the devices extension is added to the extension blacklist, then this code should be put back in with a check to see if the devices extension is being used or not, to prevent the devices from being added to docker_args twice.

I find it interesting that removing accidentally duplicated code can cause an automated check for percent code coverage to fail. Seems like it might be a little better if the coverage test failed only when non-covered code is added to a file, rather than failing when covered code is removed and that reduces the coverage percentage.