### PR TITLE
[fix] os_detect syntax error with Python 3.5 or earlier.

### DIFF
--- a/src/rocker/os_detector.py
+++ b/src/rocker/os_detector.py
@@ -57,7 +57,7 @@ def detect_os(image_name, output_callback=None, nocache=False):
         output_callback=output_callback,
         nocache=nocache,
         forcerm=True,  # Remove intermediate containers from RUN commands in DETECTION_TEMPLATE
-        tag="rocker:" + f"os_detect_{image_name}".replace(':', '_').replace('/', '_')
+        tag="rocker:" + "os_detect_{}".format(image_name).replace(':', '_').replace('/', '_')
     )
     if not image_id:
         if output_callback:


### PR DESCRIPTION
# Problem aimed to be resolved

#143

# Approach

Switch back to older `format` style. `f-string`, which seems to have become available after Py 3.6, is nice but it's only one line that is causing #143 and I'd say the current implementation is not heavily relying on f-string's advantage. 
