### PR TITLE
Fix os detection for non-root images

### DIFF
--- a/src/rocker/os_detector.py
+++ b/src/rocker/os_detector.py
@@ -37,6 +37,8 @@ RUN . /tmp/distrovenv/bin/activate && pyinstaller --onefile /tmp/distrovenv/dete
 
 RUN . /tmp/distrovenv/bin/activate && staticx /dist/detect_os /dist/detect_os_static
 
+RUN chmod go+xr /dist/detect_os_static
+
 FROM %(image_name)s
 
 COPY --from=detector /dist/detect_os_static /tmp/detect_os


### PR DESCRIPTION
The `detect_os` executable has execution permission set for it's owner (i.e. `root`) only. When attempting to run an image that has a default non-`root` user, this causes a _permission denied_ error in the [entrypoint](https://github.com/osrf/rocker/blob/9d7a3924cd0d9a4c45ea163a7ab5296e4cdfdd3c/src/rocker/os_detector.py#L43).

This simple fix should solve the issue.