### PR TITLE
Fix os detection for non-root images (cont.)

### DIFF
--- a/src/rocker/os_detector.py
+++ b/src/rocker/os_detector.py
@@ -37,6 +37,8 @@ RUN . /tmp/distrovenv/bin/activate && pyinstaller --onefile /tmp/distrovenv/dete
 
 RUN . /tmp/distrovenv/bin/activate && staticx /dist/detect_os /dist/detect_os_static
 
+RUN chmod go+xr /dist/detect_os_static
+
 FROM %(image_name)s
 
 COPY --from=detector /dist/detect_os_static /tmp/detect_os

--- a/src/rocker/os_detector.py
+++ b/src/rocker/os_detector.py
@@ -35,9 +35,7 @@ RUN apt-get update && apt-get install -qy patchelf #needed for staticx
 RUN echo 'import distro; import sys; output = distro.linux_distribution(); print(output) if output[0] else sys.exit(1)' > /tmp/distrovenv/detect_os.py
 RUN . /tmp/distrovenv/bin/activate && pyinstaller --onefile /tmp/distrovenv/detect_os.py
 
-RUN . /tmp/distrovenv/bin/activate && staticx /dist/detect_os /dist/detect_os_static
-
-RUN chmod go+xr /dist/detect_os_static
+RUN . /tmp/distrovenv/bin/activate && staticx /dist/detect_os /dist/detect_os_static && chmod go+xr /dist/detect_os_static
 
 FROM %(image_name)s
 


### PR DESCRIPTION
This is a continuation of #149. I made the mistake of opening the PR directly from a branch in my colleague's fork without realizing I don't have push access to that. Apologies for the inconvenience.

I think this PR also addresses the [comment](https://github.com/osrf/rocker/pull/149#pullrequestreview-676744607) by @tfoote by appending the `chmod` onto the previous `RUN` command.

As for the reproduction example, you can trigger the error by creating an image with a non-root user, and then try to run that image with the `--nvidia` flag.

For instance, this

```bash
mkdir -p /tmp/context && cd /tmp/context
cat <<EOF > Dockerfile
FROM ros:melodic
RUN useradd -ms /bin/bash someuser
USER someuser
EOF
docker build -t deletethis .
rocker --nvidia deletethis
```

fails for me on `main`, whereas it passes ok with the fix.