### PR TITLE
add an option to preserve the home directory instead of deleting it if the uid or username collide

### DIFF
--- a/src/rocker/extensions.py
+++ b/src/rocker/extensions.py
@@ -232,7 +232,7 @@ class User(RockerExtension):
             help="mount the current user's id and run as that user")
         parser.add_argument('--user-override-name',
             action='store',
-            default=defaults.get('user-override-username', None),
+            default=defaults.get('user-override-name', None),
             help="override the current user's name")
         parser.add_argument('--user-preserve-home',
             action='store_true',

--- a/src/rocker/extensions.py
+++ b/src/rocker/extensions.py
@@ -220,7 +220,7 @@ class User(RockerExtension):
         if 'user_override_name' in cliargs and cliargs['user_override_name']:
             substitutions['name'] = cliargs['user_override_name']
             substitutions['dir'] = os.path.join('/home/', cliargs['user_override_name'])
-        substitutions['user_preserve_home'] = cliargs['user_preserve_home']
+        substitutions['user_preserve_home'] = True if 'user_preserve_home' in cliargs and cliargs['user_preserve_home'] else False
         substitutions['home_extension_active'] = True if 'home' in cliargs and cliargs['home'] else False
         return em.expand(snippet, substitutions)
 
@@ -236,7 +236,7 @@ class User(RockerExtension):
             help="override the current user's name")
         parser.add_argument('--user-preserve-home',
             action='store_true',
-            default=defaults.get('user-preserve-home', None),
+            default=defaults.get('user-preserve-home', False),
             help="Do not delete home directory if it exists when making a new user.")
 
 

--- a/src/rocker/extensions.py
+++ b/src/rocker/extensions.py
@@ -220,6 +220,7 @@ class User(RockerExtension):
         if 'user_override_name' in cliargs and cliargs['user_override_name']:
             substitutions['name'] = cliargs['user_override_name']
             substitutions['dir'] = os.path.join('/home/', cliargs['user_override_name'])
+        substitutions['user_preserve_home'] = cliargs['user_preserve_home']
         substitutions['home_extension_active'] = True if 'home' in cliargs and cliargs['home'] else False
         return em.expand(snippet, substitutions)
 
@@ -233,6 +234,10 @@ class User(RockerExtension):
             action='store',
             default=defaults.get('user-override-username', None),
             help="override the current user's name")
+        parser.add_argument('--user-preserve-home',
+            action='store_true',
+            default=defaults.get('user-preserve-home', None),
+            help="Do not delete home directory if it exists when making a new user.")
 
 
 class Environment(RockerExtension):

--- a/src/rocker/templates/user_snippet.Dockerfile.em
+++ b/src/rocker/templates/user_snippet.Dockerfile.em
@@ -7,9 +7,9 @@ RUN if ! command -v sudo >/dev/null; then \
 
 @[if name != 'root']@
 RUN existing_user_by_uid=`getent passwd "@(uid)" | cut -f1 -d: || true` && \
-    if [ -n "${existing_user_by_uid}" ]; then userdel -r "${existing_user_by_uid}"; fi && \
+    if [ -n "${existing_user_by_uid}" ]; then userdel @('' if user_preserve_home else '-r') "${existing_user_by_uid}"; fi && \
     existing_user_by_name=`getent passwd "@(name)" | cut -f1 -d: || true` && \
-    if [ -n "${existing_user_by_name}" ]; then userdel -r "${existing_user_by_name}"; fi && \
+    if [ -n "${existing_user_by_name}" ]; then userdel @('' if user_preserve_home else '-r') "${existing_user_by_name}"; fi && \
     existing_group_by_gid=`getent group "@(gid)" | cut -f1 -d: || true` && \
     if [ -z "${existing_group_by_gid}" ]; then \
       groupadd -g "@(gid)" "@name"; \

--- a/test/test_extension.py
+++ b/test/test_extension.py
@@ -248,10 +248,15 @@ class UserExtensionTest(unittest.TestCase):
 
         user_override_active_cliargs = mock_cliargs
         user_override_active_cliargs['user_override_name'] = 'testusername'
-        print(p.get_snippet(user_override_active_cliargs))
         snippet_result = p.get_snippet(user_override_active_cliargs)
         self.assertTrue('USER testusername' in snippet_result)
         self.assertTrue('WORKDIR /home/testusername' in snippet_result)
+        self.assertTrue('userdel -r' in snippet_result)
+
+        user_override_active_cliargs['user_preserve_home'] = True
+        snippet_result = p.get_snippet(user_override_active_cliargs)
+        self.assertFalse('userdel -r' in snippet_result)
+
 
 
 class PulseExtensionTest(unittest.TestCase):


### PR DESCRIPTION
This allows persistence of existing content in home directories from underlays if not using the --home option.