### PR TITLE
Volume argument parsing change proposal

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,17 +142,19 @@ On Bionic
 
 ## Volume mount
 
-For arguments with one element not colon separated.
+### For arguments with one element not colon separated
 
-`--volume` adds paths as docker volumes. The last path must be terminated with two dashes `--`.
+`--volume` adds paths as docker volumes. One `--volume` directive must be used for each path.
 
-    rocker --volume ~/.vimrc ~/.bashrc -- ubuntu:18.04
+    rocker --volume ~/.vimrc --volume ~/.bashrc ubuntu:18.04
 
 The above example of the volume option will be expanded via absolute paths for `docker run` as follows:
 
     --volume /home/<USERNAME>/.vimrc:/home/<USERNAME>/.vimrc --volume /home/<USERNAME>/.bashrc:/home/<USERNAME>/.bashrc  
 
-For arguments with colon separation it will process the same as `docker`'s `--volume` option, `rocker --volume` takes 3 fields.
+### For arguments with colon separation
+
+it will process the same as `docker`'s `--volume` option, `rocker --volume` takes 3 fields.
 - 1st field: the path to the file or directory on the host machine.
 - 2nd field: (optional) the path where the file or directory is mounted in the container.
    - If only the 1st field is supplied, same value as the 1st field will be populated as the 2nd field.

--- a/src/rocker/volume_extension.py
+++ b/src/rocker/volume_extension.py
@@ -40,7 +40,7 @@ class Volume(RockerExtension):
         args = ['']
 
         # flatten cli_args['volume']
-        volumes = [ x for sublist in cli_args[self.name] for x in sublist]
+        volumes = [ x for x in cli_args[self.name] ]
 
         for volume in volumes:
             elems = volume.split(':')
@@ -65,6 +65,6 @@ class Volume(RockerExtension):
         parser.add_argument(Volume.ARG_ROCKER_VOLUME,
             metavar='HOST-DIR[:CONTAINER-DIR[:OPTIONS]]',
             type=str,
-            nargs='+',
             action='append',
-            help='volume volumes in container')
+            default=[],
+            help='volumes to map, can have more than one --volume directive')


### PR DESCRIPTION
This is a proposal, as the the [README.md](https://stackoverflow.com/a/36338204) actually specifies that the last path should be terminated with `--`, but I missed that. This made me lose quite a bit of time understanding what was going on since I was trying to bind volumes as follows:

```
rocker --nvidia --x11 --name iaslab --volume "$HOME/my/folder:/container/folder" user/image
Extension volume doesn't support default arguments. Please extend it.
usage: rocker [-h] [--noexecute] [--nocache] [--nocleanup] [--pull] [-v] [--dev-helpers]
              [--devices [DEVICES [DEVICES ...]]] [--env NAME[=VALUE] [NAME[=VALUE] ...]]
              [--env-file ENV_FILE] [--git] [--git-config-path GIT_CONFIG_PATH] [--home]
              [--name NAME] [--network {host,none,bridge}] [--nvidia] [--privileged]
              [--pulse] [--ssh] [--user] [--user-override-name USER_OVERRIDE_NAME]
              [--user-preserve-home] [--volume HOST-DIR[:CONTAINER-DIR[:OPTIONS]]
              [HOST-DIR[:CONTAINER-DIR[:OPTIONS]] ...]] [--x11]
              [--mode {interactive,non-interactive,dry-run}] [--image-name IMAGE_NAME]
              [--extension-blacklist [EXTENSION_BLACKLIST [EXTENSION_BLACKLIST ...]]]
              image [command [command ...]]
rocker: error: the following arguments are required: image
```

The argument parser for the `--volume` flag, being configured with `nargs='+'`, was causing the `--volume` directive to eat up the *image* positional argument if used as last optional one (also see [this StackOverflow issue](https://stackoverflow.com/a/36338204)). 
Adopting this change makes the configuration of volumes so that each bind is specified with its own `--volume` flag.

I think that this approach is slightly better (and also more inline with the way the Docker CLI handles it). If changing the code is not possible or wanted, I propose to document the need for `--` in the `rocker --help` message.

Co-authored with @gdelazzari