### PR TITLE
If the same username exists with a different uid adopt their files so the newly created user has access.

### DIFF
--- a/src/rocker/templates/user_snippet.Dockerfile.em
+++ b/src/rocker/templates/user_snippet.Dockerfile.em
@@ -9,6 +9,8 @@ RUN if ! command -v sudo >/dev/null; then \
 RUN existing_user_by_uid=`getent passwd "@(uid)" | cut -f1 -d: || true` && \
     if [ -n "${existing_user_by_uid}" ]; then userdel @('' if user_preserve_home else '-r') "${existing_user_by_uid}"; fi && \
     existing_user_by_name=`getent passwd "@(name)" | cut -f1 -d: || true` && \
+    existing_user_uid=`getent passwd "@(name)" | cut -f3 -d: || true` && \
+    if [ -n "${existing_user_by_name}" ]; then find / -uid ${existing_user_uid} -exec chown -h @(uid) {} + || true ; find / -gid ${existing_user_uid} -exec chgrp -h @(uid) {} + || true ; fi && \
     if [ -n "${existing_user_by_name}" ]; then userdel @('' if user_preserve_home else '-r') "${existing_user_by_name}"; fi && \
     existing_group_by_gid=`getent group "@(gid)" | cut -f1 -d: || true` && \
     if [ -z "${existing_group_by_gid}" ]; then \


### PR DESCRIPTION
The UID of a user in an underlay environment was blocking execution because it collided with the current user and consequently 

This is a potentially slow step and may want to be possible to disable. There may be overlap with whether the home should be preserved.