### PR TITLE
Update debian packaging targets

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -3,5 +3,5 @@ Debian-Version: 100
 No-Python2:
 Depends3: python3-docker, python3-empy, python3-pexpect, python3-packaging
 Conflicts3: python-rocker
-Suite: xenial yakkety zesty artful bionic cosmic disco eoan focal stretch buster
+Suite: bionic focal jammy stretch buster bullseye
 X-Python3-Version: >= 3.2


### PR DESCRIPTION
Remove most EOL targests, and add a few of the newer ones

Signed-off-by: Tully Foote <tfoote@osrfoundation.org>