### PR TITLE
Make using user shell optional

### DIFF
--- a/src/rocker/extensions.py
+++ b/src/rocker/extensions.py
@@ -222,6 +222,11 @@ class User(RockerExtension):
             substitutions['dir'] = os.path.join('/home/', cliargs['user_override_name'])
         substitutions['user_preserve_home'] = True if 'user_preserve_home' in cliargs and cliargs['user_preserve_home'] else False
         substitutions['home_extension_active'] = True if 'home' in cliargs and cliargs['home'] else False
+        if 'user_override_shell' in cliargs and cliargs['user_override_shell'] is not None:
+            if cliargs['user_override_shell'] == '':
+                substitutions['shell'] = None
+            else:
+                substitutions['shell'] =  cliargs['user_override_shell']
         return em.expand(snippet, substitutions)
 
     @staticmethod
@@ -238,6 +243,10 @@ class User(RockerExtension):
             action='store_true',
             default=defaults.get('user-preserve-home', False),
             help="Do not delete home directory if it exists when making a new user.")
+        parser.add_argument('--user-override-shell',
+            action='store',
+            default=defaults.get('user-override-shell', None),
+            help="Override the current user's shell. Set to empty string to use container default shell")
 
 
 class Environment(RockerExtension):

--- a/src/rocker/templates/user_snippet.Dockerfile.em
+++ b/src/rocker/templates/user_snippet.Dockerfile.em
@@ -16,7 +16,7 @@ RUN existing_user_by_uid=`getent passwd "@(uid)" | cut -f1 -d: || true` && \
     if [ -z "${existing_group_by_gid}" ]; then \
       groupadd -g "@(gid)" "@name"; \
     fi && \
-    useradd --no-log-init --no-create-home --uid "@(uid)" -s "@(shell)" -c "@(gecos)" -g "@(gid)" -d "@(dir)" "@(name)" && \
+    useradd --no-log-init --no-create-home --uid "@(uid)" @(str('-s ' + shell) if shell else '') -c "@(gecos)" -g "@(gid)" -d "@(dir)" "@(name)" && \
     echo "@(name) ALL=NOPASSWD: ALL" >> /etc/sudoers.d/rocker
 
 @[if not home_extension_active ]@

--- a/test/test_extension.py
+++ b/test/test_extension.py
@@ -260,6 +260,17 @@ class UserExtensionTest(unittest.TestCase):
         snippet_result = p.get_snippet(user_override_active_cliargs)
         self.assertFalse('userdel -r' in snippet_result)
 
+        snippet_result = p.get_snippet(user_override_active_cliargs)
+        self.assertTrue(('-s ' + pwd.getpwuid(os.getuid()).pw_shell) in snippet_result)
+
+        user_override_active_cliargs['user_override_shell'] = 'testshell'
+        snippet_result = p.get_snippet(user_override_active_cliargs)
+        self.assertTrue('-s testshell' in snippet_result)
+
+        user_override_active_cliargs['user_override_shell'] = ''
+        snippet_result = p.get_snippet(user_override_active_cliargs)
+        self.assertFalse('-s' in snippet_result)
+
     def test_user_collisions(self):
         plugins = list_plugins()
         user_plugin = plugins['user']


### PR DESCRIPTION
Resolves https://github.com/osrf/rocker/issues/183

Adds option `--use-user-shell` and changes default behavior to not override container shell

Let me know if you disagree with this change in default behavior and I'll amend this to implement `--user-override-shell` instead