### PR TITLE
Added note for linking Intel Xe cards with rocker

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,16 +42,10 @@ Note, that changing this setting will lead to a `Failed to initialize NVML: Unkn
 
 ## Intel integrated graphics support
 
-For intel integrated graphics support you will need to mount through a specific device
+For [Intel integrated graphics support](https://www.intel.com/content/www/us/en/develop/documentation/get-started-with-ai-linux/top/using-containers/using-containers-with-the-command-line.html) you will need to mount the `/dev/dri` directory as follows:
 
 ```
---devices /dev/dri/card0
-```
-
-For Intel Xe integrated graphics, you will need to use the `renderD128` option instead:
-
-```
----devices /dev/dri/renderD128
+--devices /dev/dri
 ```
 
 # Installation

--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ For intel integrated graphics support you will need to mount through a specific 
 --devices /dev/dri/card0
 ```
 
+For Intel Xe integrated graphics, you will need to use the `renderD128` option instead:
+
+```
+---devices /dev/dri/renderD128
+```
 
 # Installation
 


### PR DESCRIPTION
When running on an 11th gen Intel processor, I continually got a `(Segmentation Fault)` and `Forcing OpenGl version 0.` error when launching Rviz or any other GUI that required accelerated graphics within a container. This only happened when I linked the integrated graphics with the `--devices /dev/dri/card0` option as suggested by the documentation.

Further research showed that the `/dev/dri/renderD128` is the correct device to link for Intel chipsets with Xe graphics. Therefore, I've added an extra note on the `rocker` README for future users.

Please let me know if there is anything else I should change!