### PR TITLE
Drop executable and shebang from non-scripts in module

### DIFF
--- a/src/rocker/cli.py
+++ b/src/rocker/cli.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # Copyright 2019 Open Source Robotics Foundation
 
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/rocker/core.py
+++ b/src/rocker/core.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # Copyright 2019 Open Source Robotics Foundation
 
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
These files are executable and contain a shebang, but do nothing when executed.