### PR TITLE
Run tests with pytest instead of nose

### DIFF
--- a/.github/workflows/basic-ci.yaml
+++ b/.github/workflows/basic-ci.yaml
@@ -19,11 +19,11 @@ jobs:
         python -m pip install --upgrade pip setuptools wheel
         # Workaround for https://github.com/docker/docker-py/issues/2807
         python -m pip install six
-        pip install codecov coverage nose
+        pip install codecov pytest pytest-cov
         pip install .
     - name: Run headless tests
       uses: GabrielBB/xvfb-action@v1
       with:
-        run: nosetests -s -v --with-coverage --cover-package rocker --exclude test_nvidia_glmark2
+        run: python -m pytest -s -v --cov=rocker -k "not test_nvidia_glmark2"
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1

--- a/README.md
+++ b/README.md
@@ -100,19 +100,19 @@ For any new terminal re activate the venv before trying to use it.
 
 ### Testing
 
-To run tests install nose and coverage in the venv
+To run tests install pytest and pytest-cov in the venv
 
     . ~/rocker_venv/bin/activate
-    pip install nose
-    pip install coverage
+    pip install pytest
+    pip install pytest-cov
 
-Then you can run nosetests.
+Then you can run pytest.
 
-    nosetests-3.4 --with-coverage --cover-package rocker
+    python3 -m pytest --cov=rocker
 
 Notes:
 
-- Make sure to use the python3 instance of nosetest from inside the environment.
+- Make sure to use the python3 instance of pytest from inside the environment.
 - The tests include an nvidia test which assumes you're using a machine with an nvidia gpu.
 
 


### PR DESCRIPTION
The 'nose' package is no longer under active development and it is generally recommended to move to a more supported Python testing framework.