### PR TITLE
Mark tests which have external dependencies

### DIFF
--- a/.github/workflows/basic-ci.yaml
+++ b/.github/workflows/basic-ci.yaml
@@ -24,6 +24,6 @@ jobs:
     - name: Run headless tests
       uses: GabrielBB/xvfb-action@v1
       with:
-        run: python -m pytest -s -v --cov=rocker -k "not test_nvidia_glmark2"
+        run: python -m pytest -s -v --cov=rocker -m "not nvidia"
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,8 @@
+[tool:pytest]
+markers =
+  # Tests which require a docker engine
+  docker
+  # Tests which require an NVIDIA GPU and drivers
+  nvidia
+  # Tests which require an X11 display of some kind
+  x11

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -17,6 +17,7 @@
 
 import argparse
 import em
+import pytest
 import unittest
 
 from itertools import chain
@@ -56,18 +57,21 @@ class RockerCoreTest(unittest.TestCase):
             # Check that it can be cast to an int
             i = int(p)
 
+    @pytest.mark.docker
     def test_run_before_build(self):
         dig = DockerImageGenerator([], {}, 'ubuntu:bionic')
         self.assertEqual(dig.run('true'), 1)
         self.assertEqual(dig.build(), 0)
         self.assertEqual(dig.run('true'), 0)
 
+    @pytest.mark.docker
     def test_return_code_no_extensions(self):
         dig = DockerImageGenerator([], {}, 'ubuntu:bionic')
         self.assertEqual(dig.build(), 0)
         self.assertEqual(dig.run('true'), 0)
         self.assertEqual(dig.run('false'), 1)
 
+    @pytest.mark.docker
     def test_return_code_multiple_extensions(self):
         plugins = list_plugins()
         desired_plugins = ['home', 'user']
@@ -77,29 +81,34 @@ class RockerCoreTest(unittest.TestCase):
         self.assertEqual(dig.run('true'), 0)
         self.assertEqual(dig.run('false'), 1)
 
+    @pytest.mark.docker
     def test_noexecute(self):
         dig = DockerImageGenerator([], {}, 'ubuntu:bionic')
         self.assertEqual(dig.build(), 0)
         self.assertEqual(dig.run('true', noexecute=True), 0)
 
+    @pytest.mark.docker
     def test_dry_run(self):
         dig = DockerImageGenerator([], {}, 'ubuntu:bionic')
         self.assertEqual(dig.build(), 0)
         self.assertEqual(dig.run('true', mode='dry-run'), 0)
         self.assertEqual(dig.run('false', mode='dry-run'), 0)
 
+    @pytest.mark.docker
     def test_non_interactive(self):
         dig = DockerImageGenerator([], {}, 'ubuntu:bionic')
         self.assertEqual(dig.build(), 0)
         self.assertEqual(dig.run('true', mode='non-interactive'), 0)
         self.assertEqual(dig.run('false', mode='non-interactive'), 1)
 
+    @pytest.mark.docker
     def test_device(self):
         dig = DockerImageGenerator([], {}, 'ubuntu:bionic')
         self.assertEqual(dig.build(), 0)
         self.assertEqual(dig.run('true', devices=['/dev/random']), 0)
         self.assertEqual(dig.run('true', devices=['/dev/does_not_exist']), 0)
 
+    @pytest.mark.docker
     def test_network(self):
         dig = DockerImageGenerator([], {}, 'ubuntu:bionic')
         self.assertEqual(dig.build(), 0)
@@ -107,6 +116,7 @@ class RockerCoreTest(unittest.TestCase):
         for n in networks:
             self.assertEqual(dig.run('true', network=n), 0)
 
+    @pytest.mark.docker
     def test_extension_manager(self):
         parser = argparse.ArgumentParser()
         extension_manager = RockerExtensionManager()

--- a/test/test_extension.py
+++ b/test/test_extension.py
@@ -22,6 +22,7 @@ import os
 import unittest
 from pathlib import Path
 import pwd
+import pytest
 from io import BytesIO as StringIO
 
 
@@ -126,6 +127,7 @@ class NetworkExtensionTest(unittest.TestCase):
         # "em.Error: interpreter stdout proxy lost"
         em.Interpreter._wasProxyInstalled = False
 
+    @pytest.mark.docker
     def test_network_extension(self):
         plugins = list_plugins()
         network_plugin = plugins['network']
@@ -271,6 +273,7 @@ class UserExtensionTest(unittest.TestCase):
         snippet_result = p.get_snippet(user_override_active_cliargs)
         self.assertFalse('-s' in snippet_result)
 
+    @pytest.mark.docker
     def test_user_collisions(self):
         plugins = list_plugins()
         user_plugin = plugins['user']

--- a/test/test_nvidia.py
+++ b/test/test_nvidia.py
@@ -19,6 +19,7 @@ import docker
 import em
 import unittest
 import pexpect
+import pytest
 
 
 from io import BytesIO as StringIO
@@ -31,6 +32,7 @@ from rocker.nvidia_extension import get_docker_version
 from test_extension import plugin_load_parser_correctly
 
 
+@pytest.mark.docker
 class X11Test(unittest.TestCase):
     @classmethod
     def setUpClass(self):
@@ -98,6 +100,7 @@ CMD xdpyinfo
             self.assertEqual(dig.build(), 0)
             self.assertNotEqual(dig.run(), 0)
 
+    @pytest.mark.x11
     def test_x11_xpdyinfo(self):
         plugins = list_plugins()
         desired_plugins = ['x11']
@@ -108,6 +111,7 @@ CMD xdpyinfo
             self.assertEqual(dig.run(), 0)
 
 
+@pytest.mark.docker
 class NvidiaTest(unittest.TestCase):
     @classmethod
     def setUpClass(self):
@@ -188,6 +192,8 @@ CMD glmark2 --validate
             self.assertEqual(dig.build(), 0)
             self.assertNotEqual(dig.run(), 0)
 
+    @pytest.mark.nvidia
+    @pytest.mark.x11
     def test_nvidia_glmark2(self):
         plugins = list_plugins()
         desired_plugins = ['x11', 'nvidia', 'user'] #TODO(Tfoote) encode the x11 dependency into the plugin and remove from test here

--- a/test/test_os_detect.py
+++ b/test/test_os_detect.py
@@ -16,6 +16,7 @@
 # under the License.
 
 import docker
+import pytest
 import unittest
 
 
@@ -23,6 +24,7 @@ from rocker.os_detector import detect_os
 
 class RockerOSDetectorTest(unittest.TestCase):
 
+    @pytest.mark.docker
     def test_ubuntu(self):
         result = detect_os("ubuntu:xenial")
         self.assertEqual(result[0], 'Ubuntu')
@@ -37,15 +39,18 @@ class RockerOSDetectorTest(unittest.TestCase):
         self.assertEqual(result[0], 'Ubuntu')
         self.assertEqual(result[1], '18.04')
 
+    @pytest.mark.docker
     def test_fedora(self):
         result = detect_os("fedora:29")
         self.assertEqual(result[0], 'Fedora')
         self.assertEqual(result[1], '29')
 
+    @pytest.mark.docker
     def test_does_not_exist(self):
         result = detect_os("osrf/ros:does_not_exist")
         self.assertEqual(result, None)
 
+    @pytest.mark.docker
     def test_cannot_detect_os(self):
         # Test with output callback too get coverage of error reporting
         result = detect_os("scratch", output_callback=print)


### PR DESCRIPTION
There are three classes of external requirements that I've found in these tests:
* Tests which require a docker engine
* Tests which require an NVIDIA GPU and drivers
* Tests which require an X11 display of some kind

Any of these could be unavailable for some reason, so it makes sense to add labels so that they can be easily skipped.