### PR TITLE
Declare test dependency on pytest using extras_require

### DIFF
--- a/.github/workflows/basic-ci.yaml
+++ b/.github/workflows/basic-ci.yaml
@@ -19,8 +19,7 @@ jobs:
         python -m pip install --upgrade pip setuptools wheel
         # Workaround for https://github.com/docker/docker-py/issues/2807
         python -m pip install six
-        pip install codecov pytest pytest-cov
-        pip install .
+        python -m pip install -e .[test] codecov pytest-cov
     - name: Run headless tests
       uses: GabrielBB/xvfb-action@v1
       with:

--- a/README.md
+++ b/README.md
@@ -100,11 +100,10 @@ For any new terminal re activate the venv before trying to use it.
 
 ### Testing
 
-To run tests install pytest and pytest-cov in the venv
+To run tests install the 'test' extra and pytest-cov in the venv
 
     . ~/rocker_venv/bin/activate
-    pip install pytest
-    pip install pytest-cov
+    pip install -e .[test] pytest-cov
 
 Then you can run pytest.
 

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,11 @@ kwargs = {
     'python_requires': '>=3.0',
 
     'install_requires': install_requires,
+    'extras_require': {
+        'test': [
+            'pytest'
+        ]
+    },
     'url': 'https://github.com/osrf/rocker'
 }
 


### PR DESCRIPTION
This same approach to declaring test dependencies has been taken in several ros-infrastructure and colcon packages, and allows tools like colcon to invoke the appropriate testing framework.

Fedora has also adopted this approach in packaging automation: https://docs.fedoraproject.org/en-US/packaging-guidelines/Python/#_test_dependencies_2