### PR TITLE
Removed '-v' for rocker's version. Only --version should be available.

### DIFF
--- a/src/rocker/cli.py
+++ b/src/rocker/cli.py
@@ -35,7 +35,7 @@ def main():
     parser.add_argument('--nocache', action='store_true')
     parser.add_argument('--nocleanup', action='store_true', help='do not remove the docker container when stopped')
     parser.add_argument('--pull', action='store_true')
-    parser.add_argument('-v', '--version', action='version',
+    parser.add_argument('--version', action='version',
         version='%(prog)s ' + get_rocker_version())
 
     try:


### PR DESCRIPTION
The reasoning between this change is that it creates a conflict with the -v flag of the `docker volume` extension.