### PR TITLE
Fix nvidia runtime fail on arm64 & add --group-add plugin

### DIFF
--- a/src/rocker/nvidia_extension.py
+++ b/src/rocker/nvidia_extension.py
@@ -123,6 +123,11 @@ class Nvidia(RockerExtension):
         return em.expand(snippet, self.get_environment_subs(cliargs))
 
     def get_docker_args(self, cliargs):
+        force_flag = cliargs.get('nvidia', None)
+        if force_flag == 'runtime':
+            return "  --runtime=nvidia"
+        if force_flag == 'gpus':
+            return "  --gpus all"
         if get_docker_version() >= Version("19.03"):
             return "  --gpus all"
         return "  --runtime=nvidia"
@@ -130,9 +135,11 @@ class Nvidia(RockerExtension):
     @staticmethod
     def register_arguments(parser, defaults={}):
         parser.add_argument(name_to_argument(Nvidia.get_name()),
-            action='store_true',
-            default=defaults.get(Nvidia.get_name(), None),
-            help="Enable nvidia")
+            choices=['auto', 'runtime', 'gpus'],
+            nargs='?',
+            const='auto',
+            default=defaults.get(Nvidia.get_name(), 'auto'),
+            help="Enable nvidia. Default behavior is to pick flag based on docker version.")
 
 class Cuda(RockerExtension):
     @staticmethod

--- a/test/test_nvidia.py
+++ b/test/test_nvidia.py
@@ -185,6 +185,21 @@ CMD glmark2 --validate
         else:
             self.assertIn(' --runtime=nvidia', docker_args)
 
+        mock_cliargs = {'nvidia': 'auto'}
+        docker_args = p.get_docker_args(mock_cliargs)
+        if get_docker_version() >= Version("19.03"):
+            self.assertIn(' --gpus all', docker_args)
+        else:
+            self.assertIn(' --runtime=nvidia', docker_args)
+
+        mock_cliargs = {'nvidia': 'gpus'}
+        docker_args = p.get_docker_args(mock_cliargs)
+        self.assertIn(' --gpus all', docker_args)
+
+        mock_cliargs = {'nvidia': 'runtime'}
+        docker_args = p.get_docker_args(mock_cliargs)
+        self.assertIn(' --runtime=nvidia', docker_args)
+
 
     def test_no_nvidia_glmark2(self):
         for tag in self.dockerfile_tags:


### PR DESCRIPTION
It is not possible to run container on Nvidia Jetson Xavier NX (Jetpack 5.0.2, Docker 20.10.21)

`
Executing command:
docker run --rm -it  --gpus all -v /home/apm/autoware:/home/apm/autoware  -e DISPLAY -e TERM   -e QT_X11_NO_MITSHM=1   -e XAUTHORITY=/tmp/.dockerzb1vil5u.xauth -v /tmp/.dockerzb1vil5u.xauth:/tmp/.dockerzb1vil5u.xauth   -v /tmp/.X11-unix:/tmp/.X11-unix   -v /etc/localtime:/etc/localtime:ro  7812f082195f
docker: Error response from daemon: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: error running hook #0: error running hook: exit status 1, stdout: , stderr: Auto-detected mode as 'csv'
invoking the NVIDIA Container Runtime Hook directly (e.g. specifying the docker --gpus flag) is not supported. Please use the NVIDIA Container Runtime instead.: unknown.
`

Tiny change in `nvidia_extension.py` fixes the problem. However, execution of any window app (e.g. rviz2) causes `Segmentation fault` error. Adding user to `video` group fixes the problem. 

With these changes I ran [cuda test](https://github.com/NVIDIA/cuda-samples/tree/master/Samples/1_Utilities/deviceQuery) inside the docker with different rocker settings:

* none or `--group-add video` only

```
./deviceQuery Starting...

 CUDA Device Query (Runtime API) version (CUDART static linking)

cudaGetDeviceCount returned 35
-> CUDA driver version is insufficient for CUDA runtime version
Result = FAIL
```

* `--nvidia` only


```
./deviceQuery Starting...

 CUDA Device Query (Runtime API) version (CUDART static linking)

NvRmMemInitNvmap failed with Permission denied
549: Memory Manager Not supported



****NvRmMemInit failed**** error type: 196626


*** NvRmMemInit failed NvRmMemConstructor
cudaGetDeviceCount returned 801
-> operation not supported
Result = FAIL
```


* `--nvidia` and `--group-add video`

```
./deviceQuery Starting...
CUDA Device Query (Runtime API) version (CUDART static linking)

Detected 1 CUDA Capable device(s)

Device 0: "Xavier"
  CUDA Driver Version / Runtime Version          11.4 / 11.4
  CUDA Capability Major/Minor version number:    7.2
  Total amount of global memory:                 6847 MBytes (7179161600 bytes)
  (006) Multiprocessors, (064) CUDA Cores/MP:    384 CUDA Cores
  GPU Max Clock rate:                            1109 MHz (1.11 GHz)
  Memory Clock rate:                             1109 Mhz
  Memory Bus Width:                              256-bit
  L2 Cache Size:                                 524288 bytes
  Maximum Texture Dimension Size (x,y,z)         1D=(131072), 2D=(131072, 65536), 3D=(16384, 16384, 16384)
  Maximum Layered 1D Texture Size, (num) layers  1D=(32768), 2048 layers
  Maximum Layered 2D Texture Size, (num) layers  2D=(32768, 32768), 2048 layers
  Total amount of constant memory:               65536 bytes
  Total amount of shared memory per block:       49152 bytes
  Total shared memory per multiprocessor:        98304 bytes
  Total number of registers available per block: 65536
  Warp size:                                     32
  Maximum number of threads per multiprocessor:  2048
  Maximum number of threads per block:           1024
  Max dimension size of a thread block (x,y,z): (1024, 1024, 64)
  Max dimension size of a grid size    (x,y,z): (2147483647, 65535, 65535)
  Maximum memory pitch:                          2147483647 bytes
  Texture alignment:                             512 bytes
  Concurrent copy and kernel execution:          Yes with 1 copy engine(s)
  Run time limit on kernels:                     No
  Integrated GPU sharing Host Memory:            Yes
  Support host page-locked memory mapping:       Yes
  Alignment requirement for Surfaces:            Yes
  Device has ECC support:                        Disabled
  Device supports Unified Addressing (UVA):      Yes
  Device supports Managed Memory:                Yes
  Device supports Compute Preemption:            Yes
  Supports Cooperative Kernel Launch:            Yes
  Supports MultiDevice Co-op Kernel Launch:      Yes
  Device PCI Domain ID / Bus ID / location ID:   0 / 0 / 0
  Compute Mode:
     < Default (multiple host threads can use ::cudaSetDevice() with device simultaneously) >

deviceQuery, CUDA Driver = CUDART, CUDA Driver Version = 11.4, CUDA Runtime Version = 11.4, NumDevs = 1
Result = PASS
```

I'm not sure if gpu fix is the best idea, but what about group-add plugin in general? Is there any other way to reach that functionality? As I remember, several times my sensor needed group permission (e.g. dialout), thus I had to do it manually in terminal and attach container to new bash terminal again to refresh groups.