### PR TITLE
Add ability to preserve host user groups inside container

### DIFF
--- a/src/rocker/extensions.py
+++ b/src/rocker/extensions.py
@@ -274,6 +274,10 @@ class User(RockerExtension):
             substitutions['name'] = cliargs['user_override_name']
             substitutions['dir'] = os.path.join('/home/', cliargs['user_override_name'])
         substitutions['user_preserve_home'] = True if 'user_preserve_home' in cliargs and cliargs['user_preserve_home'] else False
+        if 'user_preserve_groups' in cliargs and cliargs['user_preserve_groups']:
+            substitutions['user_groups'] = ' '.join(['{};{}'.format(g.gr_name, g.gr_gid) for g in grp.getgrall() if substitutions['name'] in g.gr_mem])
+        else:
+            substitutions['user_groups'] = ''
         substitutions['home_extension_active'] = True if 'home' in cliargs and cliargs['home'] else False
         if 'user_override_shell' in cliargs and cliargs['user_override_shell'] is not None:
             if cliargs['user_override_shell'] == '':
@@ -296,6 +300,10 @@ class User(RockerExtension):
             action='store_true',
             default=defaults.get('user-preserve-home', False),
             help="Do not delete home directory if it exists when making a new user.")
+        parser.add_argument('--user-preserve-groups',
+            action='store_true',
+            default=defaults.get('user-preserve-groups', False),
+            help="Assign user to same groups as he belongs in host.")
         parser.add_argument('--user-override-shell',
             action='store',
             default=defaults.get('user-override-shell', None),

--- a/src/rocker/extensions.py
+++ b/src/rocker/extensions.py
@@ -278,6 +278,7 @@ class User(RockerExtension):
             substitutions['user_groups'] = ' '.join(['{};{}'.format(g.gr_name, g.gr_gid) for g in grp.getgrall() if substitutions['name'] in g.gr_mem])
         else:
             substitutions['user_groups'] = ''
+        substitutions['user_preserve_groups_permissive'] = True if 'user_preserve_groups_permissive' in cliargs and cliargs['user_preserve_groups_permissive'] else False
         substitutions['home_extension_active'] = True if 'home' in cliargs and cliargs['home'] else False
         if 'user_override_shell' in cliargs and cliargs['user_override_shell'] is not None:
             if cliargs['user_override_shell'] == '':
@@ -304,6 +305,11 @@ class User(RockerExtension):
             action='store_true',
             default=defaults.get('user-preserve-groups', False),
             help="Assign user to same groups as he belongs in host.")
+        parser.add_argument('--user-preserve-groups-permissive',
+            action='store_true',
+            default=defaults.get('user-preserve-groups-permissive', False),
+            help="If using user-preserve-groups allow failures in assignment."
+                 "This is important if the host and target have different rules. https://unix.stackexchange.com/a/11481/83370" )
         parser.add_argument('--user-override-shell',
             action='store',
             default=defaults.get('user-override-shell', None),

--- a/src/rocker/templates/user_snippet.Dockerfile.em
+++ b/src/rocker/templates/user_snippet.Dockerfile.em
@@ -22,7 +22,7 @@ RUN existing_user_by_uid=`getent passwd "@(uid)" | cut -f1 -d: || true` && \
     for groupinfo in ${user_groups}; do \
       existing_group_by_name=`getent group ${groupinfo%;*} || true`; \
       existing_group_by_gid=`getent group ${groupinfo#*;} || true`; \
-      if [ -z "${existing_group_by_name}" ] && [ -z "${existing_group_by_gid}" ]; then groupadd -g "${groupinfo#*;}" "${groupinfo%;*}" && usermod -aG "${groupinfo%;*}" "@(name)"; fi \
+      if [ -z "${existing_group_by_name}" ] && [ -z "${existing_group_by_gid}" ]; then groupadd -g "${groupinfo#*;}" "${groupinfo%;*}" && usermod -aG "${groupinfo%;*}" "@(name)" @(('|| (true && echo "user-preserve-group-permissive Enabled, continuing without processing group $groupinfo" )') if user_preserve_groups_permissive else ''); fi \
     done && \
 @[end if]@
     echo "@(name) ALL=NOPASSWD: ALL" >> /etc/sudoers.d/rocker

--- a/src/rocker/templates/user_snippet.Dockerfile.em
+++ b/src/rocker/templates/user_snippet.Dockerfile.em
@@ -17,6 +17,14 @@ RUN existing_user_by_uid=`getent passwd "@(uid)" | cut -f1 -d: || true` && \
       groupadd -g "@(gid)" "@name"; \
     fi && \
     useradd --no-log-init --no-create-home --uid "@(uid)" @(str('-s ' + shell) if shell else '') -c "@(gecos)" -g "@(gid)" -d "@(dir)" "@(name)" && \
+@[if user_groups != '']@
+    user_groups="@(user_groups)" && \
+    for groupinfo in ${user_groups}; do \
+      existing_group_by_name=`getent group ${groupinfo%;*} || true`; \
+      existing_group_by_gid=`getent group ${groupinfo#*;} || true`; \
+      if [ -z "${existing_group_by_name}" ] && [ -z "${existing_group_by_gid}" ]; then groupadd -g "${groupinfo#*;}" "${groupinfo%;*}" && usermod -aG "${groupinfo%;*}" "@(name)"; fi \
+    done && \
+@[end if]@
     echo "@(name) ALL=NOPASSWD: ALL" >> /etc/sudoers.d/rocker
 
 @[if not home_extension_active ]@

--- a/src/rocker/templates/user_snippet.Dockerfile.em
+++ b/src/rocker/templates/user_snippet.Dockerfile.em
@@ -22,7 +22,11 @@ RUN existing_user_by_uid=`getent passwd "@(uid)" | cut -f1 -d: || true` && \
     for groupinfo in ${user_groups}; do \
       existing_group_by_name=`getent group ${groupinfo%;*} || true`; \
       existing_group_by_gid=`getent group ${groupinfo#*;} || true`; \
-      if [ -z "${existing_group_by_name}" ] && [ -z "${existing_group_by_gid}" ]; then groupadd -g "${groupinfo#*;}" "${groupinfo%;*}" && usermod -aG "${groupinfo%;*}" "@(name)" @(('|| (true && echo "user-preserve-group-permissive Enabled, continuing without processing group $groupinfo" )') if user_preserve_groups_permissive else ''); fi \
+      if [ -z "${existing_group_by_name}" ] && [ -z "${existing_group_by_gid}" ]; then \
+        groupadd -g "${groupinfo#*;}" "${groupinfo%;*}" && usermod -aG "${groupinfo%;*}" "@(name)" @(('|| (true && echo "user-preserve-group-permissive Enabled, continuing without processing group $groupinfo" )') if user_preserve_groups_permissive else ''); \
+      elif [ "${existing_group_by_name}" = "${existing_group_by_gid}" ]; then \
+        usermod -aG "${groupinfo%;*}" "@(name)"; \
+      fi; \
     done && \
 @[end if]@
     echo "@(name) ALL=NOPASSWD: ALL" >> /etc/sudoers.d/rocker

--- a/test/test_extension.py
+++ b/test/test_extension.py
@@ -317,6 +317,10 @@ class UserExtensionTest(unittest.TestCase):
         self.assertFalse('mkhomedir_helper' in p.get_snippet(home_active_cliargs))
 
         user_override_active_cliargs = mock_cliargs
+        user_override_active_cliargs['user_preserve_groups'] = True
+        snippet_result = p.get_snippet(user_override_active_cliargs)
+        self.assertTrue('usermod -aG' in snippet_result)
+
         user_override_active_cliargs['user_override_name'] = 'testusername'
         snippet_result = p.get_snippet(user_override_active_cliargs)
         self.assertTrue('USER testusername' in snippet_result)

--- a/test/test_extension.py
+++ b/test/test_extension.py
@@ -321,6 +321,13 @@ class UserExtensionTest(unittest.TestCase):
         snippet_result = p.get_snippet(user_override_active_cliargs)
         self.assertTrue('usermod -aG' in snippet_result)
 
+        user_override_active_cliargs = mock_cliargs
+        user_override_active_cliargs['user_preserve_groups'] = True
+        user_override_active_cliargs['user_preserve_groups_permissive'] = True
+        snippet_result = p.get_snippet(user_override_active_cliargs)
+        self.assertTrue('usermod -aG' in snippet_result)
+        self.assertTrue('user-preserve-group-permissive Enabled' in snippet_result)
+
         user_override_active_cliargs['user_override_name'] = 'testusername'
         snippet_result = p.get_snippet(user_override_active_cliargs)
         self.assertTrue('USER testusername' in snippet_result)


### PR DESCRIPTION
I have an [extension in a personal repository](https://github.com/miguelprada/mp_rocker) which mounts the host's docker daemon socket into the container and installs the docker CLI. I can then issue docker commands against the host's daemon. However, to use it I need to either use `sudo` or manually add the user inside the container to the right group matching the host.

With this additional argument, I can automate adding the user inside the container to the same groups the host user belongs to.

Currently:

- If there's no group in the container with the same name or gid, it will create a new group in the container and add the user to it.
- It's relatively easy to add the user to groups for which both name and gid match in the host and the container, but I'm not sure whether this makes sense.
- The case where either a group with the same name or the same gid exits, but not both, is even more difficult for me to understand how to handle.