### PR TITLE
Resolving issue #153 for hostname

### DIFF
--- a/src/rocker/extensions.py
+++ b/src/rocker/extensions.py
@@ -91,6 +91,29 @@ class DevHelpers(RockerExtension):
             help="add development tools emacs and byobu to your environment")
 
 
+class Hostname(RockerExtension):
+    @staticmethod
+    def get_name():
+        return 'hostname'
+
+    def __init__(self):
+        self.name = Hostname.get_name()
+
+    def get_preamble(self, cliargs):
+        return ''
+
+    def get_docker_args(self, cliargs):
+        args = ''
+        hostname = cliargs.get('hostname', None)
+        if hostname:
+            args += ' --hostname %s ' % hostname
+        return args
+
+    @staticmethod
+    def register_arguments(parser, defaults={}):
+        parser.add_argument('--hostname', default=defaults.get('hostname', ''),
+                            help='Hostname of the container.')
+
 class Name(RockerExtension):
     @staticmethod
     def get_name():


### PR DESCRIPTION
The code for the Hostname extension in rocker/extensions.py appears to be well-structured and follows the same pattern as the Name extension, effectively adding a --hostname argument and setting the hostname run arguments for the container. 
Fixes #153 
@tfoote 