### PR TITLE
Upgrading CI versions due to deprecated results

### DIFF
--- a/.github/workflows/basic-ci.yaml
+++ b/.github/workflows/basic-ci.yaml
@@ -23,4 +23,4 @@ jobs:
       with:
         run: python -m pytest -s -v --cov=rocker -m "not nvidia"
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3

--- a/.github/workflows/basic-ci.yaml
+++ b/.github/workflows/basic-ci.yaml
@@ -19,7 +19,7 @@ jobs:
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install -e .[test] codecov pytest-cov
     - name: Run headless tests
-      uses: GabrielBB/xvfb-action@v1
+      uses: coactions/setup-xvfb@v1
       with:
         run: python -m pytest -s -v --cov=rocker -m "not nvidia"
     - name: Upload coverage to Codecov

--- a/.github/workflows/basic-ci.yaml
+++ b/.github/workflows/basic-ci.yaml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         python-version: [3.8, '3.10']
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1
       with:

--- a/.github/workflows/basic-ci.yaml
+++ b/.github/workflows/basic-ci.yaml
@@ -16,12 +16,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install Dependencies And Self
       run: |
-        docker run hello-world
-        docker --version
-        which docker
         python -m pip install --upgrade pip setuptools wheel
-        # Workaround for https://github.com/docker/docker-py/issues/2807
-        python -m pip install six
         python -m pip install -e .[test] codecov pytest-cov
     - name: Run headless tests
       uses: GabrielBB/xvfb-action@v1

--- a/.github/workflows/basic-ci.yaml
+++ b/.github/workflows/basic-ci.yaml
@@ -16,9 +16,9 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install Dependencies And Self
       run: |
+        docker run hello-world
         sudo apt-get update
         sudo apt-get install -y docker
-        docker run hello-world
         docker --version
         python -m pip install --upgrade pip setuptools wheel
         # Workaround for https://github.com/docker/docker-py/issues/2807

--- a/.github/workflows/basic-ci.yaml
+++ b/.github/workflows/basic-ci.yaml
@@ -17,8 +17,6 @@ jobs:
     - name: Install Dependencies And Self
       run: |
         docker run hello-world
-        sudo apt-get update
-        sudo apt-get install -y docker
         docker --version
         python -m pip install --upgrade pip setuptools wheel
         # Workaround for https://github.com/docker/docker-py/issues/2807

--- a/.github/workflows/basic-ci.yaml
+++ b/.github/workflows/basic-ci.yaml
@@ -18,6 +18,7 @@ jobs:
       run: |
         docker run hello-world
         docker --version
+        which docker
         python -m pip install --upgrade pip setuptools wheel
         # Workaround for https://github.com/docker/docker-py/issues/2807
         python -m pip install six

--- a/.github/workflows/basic-ci.yaml
+++ b/.github/workflows/basic-ci.yaml
@@ -11,7 +11,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Dependencies And Self

--- a/.github/workflows/basic-ci.yaml
+++ b/.github/workflows/basic-ci.yaml
@@ -16,6 +16,10 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install Dependencies And Self
       run: |
+        sudo apt-get update
+        sudo apt-get install -y docker
+        docker run hello-world
+        docker --version
         python -m pip install --upgrade pip setuptools wheel
         # Workaround for https://github.com/docker/docker-py/issues/2807
         python -m pip install six

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ install_requires = [
     'empy',
     'pexpect',
     'packaging',
+    'urllib3<2', # Workaround for https://github.com/docker/docker-py/issues/3113
 ]
 
 # docker API used to be in a package called `docker-py` before the 2.0 release


### PR DESCRIPTION
Fixes #225 225

There was a combination of outdated actions and urllib3 change in API not supported by docker-py. The current workaround will work for pip and CI, but there's a risk for debian based installations. But hopefully the debian packages will both be upgraded together and not cause an issue here. And we can remove the version log down.

