### PR TITLE
unpinning urllib3 now that the fix upstream is released

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ install_requires = [
     'empy',
     'pexpect',
     'packaging',
-    'urllib3<2', # Workaround for https://github.com/docker/docker-py/issues/3113
+    'urllib3',
 ]
 
 # docker API used to be in a package called `docker-py` before the 2.0 release


### PR DESCRIPTION
Fixes #230 

Assuming docker-py > 6.1.0 is installed from pypi or you're on distro packages with a consistent urllib3 compatibility.