### PR TITLE
Add extension ordering

### DIFF
--- a/src/rocker/cli.py
+++ b/src/rocker/cli.py
@@ -20,7 +20,7 @@ from .core import DockerImageGenerator
 from .core import get_rocker_version
 from .core import RockerExtensionManager
 from .core import DependencyMissing
-from .core import RequiredExtensionMissingError
+from .core import ExtensionError
 
 from .os_detector import detect_os
 
@@ -55,11 +55,10 @@ def main():
         args_dict['mode'] = OPERATIONS_DRY_RUN
         print('DEPRECATION Warning: --noexecute is deprecated for --mode dry-run please switch your usage by December 2020')
     
-    active_extensions = extension_manager.get_active_extensions(args_dict)
     try:
         active_extensions = extension_manager.get_active_extensions(args_dict)
-    except RequiredExtensionMissingError as e:
-        print(f"ERROR! Aborting, {str(e)}")
+    except ExtensionError as e:
+        print(f"ERROR! {str(e)}")
         return 1
     print("Active extensions %s" % [e.get_name() for e in active_extensions])
 

--- a/src/rocker/cli.py
+++ b/src/rocker/cli.py
@@ -20,6 +20,7 @@ from .core import DockerImageGenerator
 from .core import get_rocker_version
 from .core import RockerExtensionManager
 from .core import DependencyMissing
+from .core import RequiredExtensionMissingError
 
 from .os_detector import detect_os
 
@@ -55,8 +56,11 @@ def main():
         print('DEPRECATION Warning: --noexecute is deprecated for --mode dry-run please switch your usage by December 2020')
     
     active_extensions = extension_manager.get_active_extensions(args_dict)
-    # Force user to end if present otherwise it will break other extensions
-    active_extensions.sort(key=lambda e:e.get_name().startswith('user'))
+    try:
+        active_extensions = extension_manager.get_active_extensions(args_dict)
+    except RequiredExtensionMissingError as e:
+        print(f"ERROR! Aborting, {str(e)}")
+        return 1
     print("Active extensions %s" % [e.get_name() for e in active_extensions])
 
     base_image = args.image

--- a/src/rocker/core.py
+++ b/src/rocker/core.py
@@ -146,7 +146,7 @@ class RockerExtensionManager:
         return self.sort_extensions(active_extensions)
 
     @staticmethod
-    def sort_extensions(extensions):
+    def sort_extensions(extensions: typing.Dict[str, typing.Type[RockerExtension]]) -> typing.List[RockerExtension]:
 
         def topological_sort(source: typing.Dict[str, typing.Set[str]]) -> typing.List[str]:
             """Perform a topological sort on names and dependencies and returns the sorted list of names."""

--- a/src/rocker/core.py
+++ b/src/rocker/core.py
@@ -141,8 +141,7 @@ class RockerExtensionManager:
         required() method) and additionally sorts them.
         """
         active_extensions = {}
-        find_reqs = set([name for name, cls in self.available_plugins.items()
-            if cls.check_args_for_activation(cli_args) and cls.get_name() not in cli_args['extension_blacklist']])
+        find_reqs = set([name for name, cls in self.available_plugins.items() if cls.check_args_for_activation(cli_args)])
         while find_reqs:
             name = find_reqs.pop()
 

--- a/src/rocker/core.py
+++ b/src/rocker/core.py
@@ -146,7 +146,7 @@ class RockerExtensionManager:
         return self.sort_extensions(active_extensions)
 
     @staticmethod
-    def sort_extensions(extensions: typing.Dict[str, typing.Type[RockerExtension]]) -> typing.List[RockerExtension]:
+    def sort_extensions(extensions):
 
         def topological_sort(source: typing.Dict[str, typing.Set[str]]) -> typing.List[str]:
             """Perform a topological sort on names and dependencies and returns the sorted list of names."""

--- a/src/rocker/core.py
+++ b/src/rocker/core.py
@@ -50,6 +50,7 @@ class RequiredExtensionMissingError(RuntimeError):
     pass
 
 
+class RockerExtension(object):
     """The base class for Rocker extension points"""
 
     def precondition_environment(self, cliargs):
@@ -57,7 +58,7 @@ class RequiredExtensionMissingError(RuntimeError):
         pass
 
     def validate_environment(self, cliargs):
-        """Check that the environment is something that can be used.
+        """ Check that the environment is something that can be used.
         This will check that we're on the right base OS and that the 
         necessary resources are available, like hardware."""
         pass

--- a/src/rocker/core.py
+++ b/src/rocker/core.py
@@ -155,6 +155,7 @@ class RockerExtensionManager:
             else:
                 raise ExtensionError(f"Extension '{name}' not found. Is it installed?")
 
+            # add additional reqs for processing not already known about
             known_reqs = set(active_extensions.keys()).union(find_reqs)
             missing_reqs = cls.required_extensions().difference(known_reqs)
             if missing_reqs:

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -134,23 +134,43 @@ class RockerCoreTest(unittest.TestCase):
         self.assertEqual(active_extensions[0].get_name(), 'user')
 
     def test_extension_sorting(self):
+        class AUserExtension(RockerExtension):
+            @classmethod
+            def get_name(cls):
+                return 'a_user_extension'
+
+            @staticmethod
+            def preceding_extensions():
+                return {'user'}
+
+        class User(RockerExtension):
+            @classmethod
+            def get_name(cls):
+                return 'user'
+
         class Foo(RockerExtension):
             @classmethod
             def get_name(cls):
-                return "foo"
+                return 'foo'
 
         class Bar(RockerExtension):
             @classmethod
             def get_name(cls):
-                return "bar"
+                return 'bar'
 
             @staticmethod
-            def desired_extensions():
-                return {"foo"}
+            def preceding_extensions():
+                return {'foo'}
 
-        sorted_extensions = RockerExtensionManager.sort_extensions(extensions={'bar': Bar, 'foo': Foo})
-        self.assertEqual(sorted_extensions[0].get_name(), "foo")
-        self.assertEqual(sorted_extensions[1].get_name(), "bar")
+        sorted_extensions = RockerExtensionManager.sort_extensions(
+            extensions={'a_user_extension': AUserExtension,
+                        'user': User,
+                        'bar': Bar,
+                        'foo': Foo})
+        self.assertEqual(sorted_extensions[0].get_name(), 'foo')
+        self.assertEqual(sorted_extensions[1].get_name(), 'bar')
+        self.assertEqual(sorted_extensions[2].get_name(), 'user')
+        self.assertEqual(sorted_extensions[3].get_name(), 'a_user_extension')
 
     def test_docker_cmd_interactive(self):
         dig = DockerImageGenerator([], {}, 'ubuntu:bionic')

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -150,12 +150,12 @@ class RockerCoreTest(unittest.TestCase):
                 return {'foo'}
 
         extension_manager = RockerExtensionManager()
-        extension_manager.available_plugins = dict(foo=Foo, bar=Bar)
+        extension_manager.available_plugins = {'foo': Foo, 'bar': Bar}
 
-        correct_extensions = {'bar': True, 'foo': True}
+        correct_extensions = {'bar': True, 'foo': True, 'extension_blacklist': []}
         extension_manager.get_active_extensions(correct_extensions)
 
-        incorrect_extensions = {'bar': True}
+        incorrect_extensions = {'bar': True, 'extension_blacklist': []}
         self.assertRaises(RequiredExtensionMissingError,
                           extension_manager.get_active_extensions, incorrect_extensions)
 

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -130,9 +130,9 @@ class RockerCoreTest(unittest.TestCase):
         self.assertIn('non-interactive', help_str)
         self.assertIn('--extension-blacklist', help_str)
 
-        active_extensions = active_extensions = extension_manager.get_active_extensions({'user': True, 'ssh': True, 'extension_blacklist': ['ssh']})
-        self.assertEqual(len(active_extensions), 1)
-        self.assertEqual(active_extensions[0].get_name(), 'user')
+        self.assertRaises(ExtensionError,
+                          extension_manager.get_active_extensions,
+                          {'user': True, 'ssh': True, 'extension_blacklist': ['ssh']})
 
     def test_strict_required_extensions(self):
         class Foo(RockerExtension):

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -145,8 +145,7 @@ class RockerCoreTest(unittest.TestCase):
             def get_name(cls):
                 return 'bar'
 
-            @staticmethod
-            def required():
+            def required(self, cli_args):
                 return {'foo'}
 
         extension_manager = RockerExtensionManager()
@@ -170,8 +169,7 @@ class RockerCoreTest(unittest.TestCase):
             def get_name(cls):
                 return 'bar'
 
-            @staticmethod
-            def required():
+            def required(self, cli_args):
                 return {'foo'}
 
         extension_manager = RockerExtensionManager()
@@ -198,15 +196,16 @@ class RockerCoreTest(unittest.TestCase):
             def get_name(cls):
                 return 'bar'
 
-            @staticmethod
-            def invoke_after():
+            def invoke_after(self, cli_args):
                 return {'foo', 'absent_extension'}
 
-        sorted_extensions = RockerExtensionManager.sort_extensions(
-            extensions={'bar': Bar,
-                        'foo': Foo})
-        self.assertEqual(sorted_extensions[0].get_name(), 'foo')
-        self.assertEqual(sorted_extensions[1].get_name(), 'bar')
+        extension_manager = RockerExtensionManager()
+        extension_manager.available_plugins = {'foo': Foo, 'bar': Bar}
+
+        args = {'bar': True, 'foo': True, 'extension_blacklist': []}
+        active_extensions = extension_manager.get_active_extensions(args)
+        self.assertEqual(active_extensions[0].get_name(), 'foo')
+        self.assertEqual(active_extensions[1].get_name(), 'bar')
 
     def test_docker_cmd_interactive(self):
         dig = DockerImageGenerator([], {}, 'ubuntu:bionic')

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -150,6 +150,7 @@ class RockerCoreTest(unittest.TestCase):
                 return {'foo'}
 
         extension_manager = RockerExtensionManager()
+        extension_manager.available_plugins = dict(foo=Foo, bar=Bar)
 
         correct_extensions = {'bar': True, 'foo': True}
         extension_manager.get_active_extensions(correct_extensions)


### PR DESCRIPTION
Closes #37 

Adds the ability to specify required and preceding extensions for any given extension. The 'user' extension is a special case that will always be loaded last unless an extension specifically requests the 'user' extension to be loaded before.

I pulled together snippets from the [groot_rocker](https://github.com/stonier/groot_rocker) repo created by @stonier and made a few modifications of my own.