### PR TITLE
Separate out pre and post user snippets.

### DIFF
--- a/src/rocker/core.py
+++ b/src/rocker/core.py
@@ -15,6 +15,7 @@
 from collections import OrderedDict
 import io
 import os
+import pwd
 import re
 import sys
 
@@ -62,6 +63,11 @@ class RockerExtension(object):
         return ''
 
     def get_snippet(self, cliargs):
+        """ Get a dockerfile snippet to be executed as ROOT."""
+        return ''
+
+    def get_user_snippet(self, cliargs):
+        """ Get a dockerfile snippet to be executed after switchingto the expected USER."""
         return ''
 
     def get_files(self, cliargs):
@@ -132,6 +138,9 @@ def get_docker_client():
             ' This is usually by being a member of the docker group.'
             ' The underlying error was:\n"""\n%s\n"""\n' % ex)
 
+def get_user_name():
+    userinfo = pwd.getpwuid(os.getuid())
+    return getattr(userinfo, 'pw_' + 'name')
 
 def docker_build(docker_client = None, output_callback = None, **kwargs):
     image_id = None
@@ -338,14 +347,27 @@ def write_files(extensions, args_dict, target_directory):
 
 def generate_dockerfile(extensions, args_dict, base_image):
     dockerfile_str = ''
+    # Preamble snippets
     for el in extensions:
         dockerfile_str += '# Preamble from extension [%s]\n' % el.name
         dockerfile_str += el.get_preamble(args_dict) + '\n'
     dockerfile_str += '\nFROM %s\n' % base_image
+    # ROOT snippets
     dockerfile_str += 'USER root\n'
     for el in extensions:
         dockerfile_str += '# Snippet from extension [%s]\n' % el.name
         dockerfile_str += el.get_snippet(args_dict) + '\n'
+    # Set USER if user extension activated
+    if 'user' in args_dict and args_dict['user']:
+        if 'user_override_name' in args_dict and args_dict['user_override_name']:
+            username = args_dict['user_override_name']
+        else:
+            username = get_user_name()
+        dockerfile_str += f'USER {username}\n'
+    # USER snippets
+    for el in extensions:
+        dockerfile_str += '# User Snippet from extension [%s]\n' % el.name
+        dockerfile_str += el.get_user_snippet(args_dict) + '\n'
     return dockerfile_str
 
 

--- a/src/rocker/templates/user_snippet.Dockerfile.em
+++ b/src/rocker/templates/user_snippet.Dockerfile.em
@@ -35,8 +35,6 @@ RUN existing_user_by_uid=`getent passwd "@(uid)" | cut -f1 -d: || true` && \
 # Making sure a home directory exists if we haven't mounted the user's home directory explicitly
 RUN mkdir -p "$(dirname "@(dir)")" && mkhomedir_helper @(name)
 @[end if]@
-# Commands below run as the developer user
-USER @(name)
 WORKDIR @(dir)
 @[else]@
 # Detected user is root, which already exists so not creating new user.

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -17,6 +17,7 @@
 
 import argparse
 import em
+import os
 import pytest
 import unittest
 
@@ -27,6 +28,7 @@ from rocker.core import list_plugins
 from rocker.core import get_docker_client
 from rocker.core import get_rocker_version
 from rocker.core import RockerExtensionManager
+from rocker.core import get_user_name
 
 class RockerCoreTest(unittest.TestCase):
 
@@ -150,6 +152,7 @@ class RockerCoreTest(unittest.TestCase):
 
 
     def test_docker_user_setting(self):
+        self.assertEqual(os.getlogin(), get_user_name())
         parser = argparse.ArgumentParser()
         extension_manager = RockerExtensionManager()
         default_args = {}

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -128,7 +128,7 @@ class RockerCoreTest(unittest.TestCase):
         self.assertIn('non-interactive', help_str)
         self.assertIn('--extension-blacklist', help_str)
 
-        active_extensions = active_extensions = extension_manager.get_active_extensions({'user': True, 'ssh': True, 'extension_blacklist': ['ssh']})
+        active_extensions = extension_manager.get_active_extensions({'user': True, 'ssh': True, 'extension_blacklist': ['ssh']})
         self.assertEqual(len(active_extensions), 1)
         self.assertEqual(active_extensions[0].get_name(), 'user')
 
@@ -147,6 +147,21 @@ class RockerCoreTest(unittest.TestCase):
             self.assertNotIn('-it', dig.generate_docker_cmd(mode='interactive'))
 
         self.assertNotIn('-it', dig.generate_docker_cmd(mode='non-interactive'))
+
+
+    def test_docker_user_setting(self):
+        parser = argparse.ArgumentParser()
+        extension_manager = RockerExtensionManager()
+        default_args = {}
+        extension_manager.extend_cli_parser(parser, default_args)
+        active_extensions = extension_manager.get_active_extensions({'user': True, 'extension_blacklist': ['ssh']})
+        dig = DockerImageGenerator(active_extensions, {'user_override_name': 'foo'}, 'ubuntu:bionic')
+
+        self.assertIn('USER root', dig.dockerfile)
+        self.assertNotIn('USER foo', dig.dockerfile)
+        dig = DockerImageGenerator(active_extensions, {'user': True, 'user_override_name': 'foo'}, 'ubuntu:bionic')
+        self.assertIn('USER root', dig.dockerfile)
+        self.assertIn('USER foo', dig.dockerfile)
 
 
     def test_docker_cmd_nocleanup(self):

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -244,6 +244,44 @@ class RockerCoreTest(unittest.TestCase):
         dig = DockerImageGenerator(active_extensions, {'user': True, 'user_override_name': 'foo'}, 'ubuntu:bionic')
         self.assertIn('USER root', dig.dockerfile)
         self.assertIn('USER foo', dig.dockerfile)
+    
+    def test_docker_user_snippet(self):
+
+        root_snippet_content = "RUN echo run as root"
+        user_snippet_content = "RUN echo run as user"
+
+        class UserSnippet(RockerExtension):
+            def __init__(self):
+                self.name = 'usersnippet'
+
+            @classmethod
+            def get_name(cls):
+                return 'usersnippet'
+
+            def get_snippet(self, cli_args):
+                return root_snippet_content
+
+
+            def get_user_snippet(self, cli_args):
+                return user_snippet_content
+
+        extension_manager = RockerExtensionManager()
+        extension_manager.available_plugins = {'usersnippet': UserSnippet}
+        active_extensions = extension_manager.get_active_extensions({'user': True, 'usersnippet': UserSnippet, 'extension_blacklist': ['ssh']})
+        self.assertTrue(active_extensions)
+
+        # No user snippet
+        mock_cli_args = {'user': False, 'usersnippet': True, 'user_override_name': 'foo'}
+        dig = DockerImageGenerator(active_extensions, mock_cli_args, 'ubuntu:bionic')
+        self.assertIn('USER root', dig.dockerfile)
+        self.assertNotIn('USER foo', dig.dockerfile)
+
+        # User snippet added
+        mock_cli_args = {'user': True, 'usersnippet': True, 'user_override_name': 'foo'}
+        dig = DockerImageGenerator(active_extensions, mock_cli_args, 'ubuntu:bionic')
+        self.assertIn(root_snippet_content, dig.dockerfile)
+        self.assertIn('USER foo', dig.dockerfile)
+        self.assertIn(user_snippet_content, dig.dockerfile)
 
     def test_docker_cmd_nocleanup(self):
         dig = DockerImageGenerator([], {}, 'ubuntu:bionic')

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -18,6 +18,7 @@
 import argparse
 import em
 import os
+import pwd
 import pytest
 import unittest
 
@@ -150,9 +151,12 @@ class RockerCoreTest(unittest.TestCase):
 
         self.assertNotIn('-it', dig.generate_docker_cmd(mode='non-interactive'))
 
+    def test_docker_user_detection(self):
+        userinfo = pwd.getpwuid(os.getuid())
+        username_detected =  getattr(userinfo, 'pw_' + 'name')
+        self.assertEqual(username_detected, get_user_name())
 
     def test_docker_user_setting(self):
-        self.assertEqual(os.getlogin(), get_user_name())
         parser = argparse.ArgumentParser()
         extension_manager = RockerExtensionManager()
         default_args = {}

--- a/test/test_extension.py
+++ b/test/test_extension.py
@@ -367,7 +367,6 @@ class UserExtensionTest(unittest.TestCase):
 
         user_override_active_cliargs['user_override_name'] = 'testusername'
         snippet_result = p.get_snippet(user_override_active_cliargs)
-        self.assertTrue('USER testusername' in snippet_result)
         self.assertTrue('WORKDIR /home/testusername' in snippet_result)
         self.assertTrue('userdel -r' in snippet_result)
 


### PR DESCRIPTION
Regular snippets can assume root access.
Post snippets can assume USER is set to the final user.

To remove special logic needed in #242 

I had thought that this would resolve #130 however the assumption in #37 "arguments are order independent as far as I know as long as they're escaped properly." Environment variables are order dependent. 

I think that the solution for that is likely to encourage plugins to set ENV values via snippet versus command line. Though that also has runtime vs build time implications.

Todos
* [ ] add coverage of the new snippets