### PR TITLE
Create directory structure when writing files

### DIFF
--- a/src/rocker/core.py
+++ b/src/rocker/core.py
@@ -325,12 +325,12 @@ class DockerImageGenerator(object):
 def write_files(extensions, args_dict, target_directory):
     all_files = {}
     for active_extension in extensions:
-        for file_name, contents in active_extension.get_files(args_dict).items():
-            if os.path.isabs(file_name):
+        for filepath, contents in active_extension.get_files(args_dict).items():
+            if os.path.isabs(filepath):
                 print('WARNING!! Path %s from extension %s is absolute'
-                      'and cannot be written out, skipping' % (file_name, active_extension.get_name()))
+                      'and cannot be written out, skipping' % (filepath, active_extension.get_name()))
                 continue
-            full_path = os.path.join(target_directory, file_name)
+            full_path = os.path.join(target_directory, filepath)
             pathlib.Path(os.path.dirname(full_path)).mkdir(exist_ok=True, parents=True)
             with open(full_path, 'w') as fh:
                 print('Writing to file %s' % full_path)

--- a/src/rocker/core.py
+++ b/src/rocker/core.py
@@ -29,6 +29,7 @@ import docker
 import pexpect
 
 import fcntl
+import pathlib
 import signal
 import struct
 import termios
@@ -330,6 +331,7 @@ def write_files(extensions, args_dict, target_directory):
                       'and cannot be written out, skipping' % (file_name, active_extension.get_name()))
                 continue
             full_path = os.path.join(target_directory, file_name)
+            pathlib.Path(os.path.dirname(full_path)).mkdir(exist_ok=True, parents=True)
             with open(full_path, 'w') as fh:
                 print('Writing to file %s' % full_path)
                 fh.write(contents)

--- a/src/rocker/core.py
+++ b/src/rocker/core.py
@@ -29,7 +29,7 @@ import docker
 import pexpect
 
 import fcntl
-import pathlib
+from pathlib import Path
 import signal
 import struct
 import termios
@@ -325,13 +325,17 @@ class DockerImageGenerator(object):
 def write_files(extensions, args_dict, target_directory):
     all_files = {}
     for active_extension in extensions:
-        for filepath, contents in active_extension.get_files(args_dict).items():
-            if os.path.isabs(filepath):
+        for file_path, contents in active_extension.get_files(args_dict).items():
+            if os.path.isabs(file_path):
                 print('WARNING!! Path %s from extension %s is absolute'
-                      'and cannot be written out, skipping' % (filepath, active_extension.get_name()))
+                      'and cannot be written out, skipping' % (file_path, active_extension.get_name()))
                 continue
-            full_path = os.path.join(target_directory, filepath)
-            pathlib.Path(os.path.dirname(full_path)).mkdir(exist_ok=True, parents=True)
+            full_path = os.path.join(target_directory, file_path)
+            if Path(target_directory).resolve() not in Path(full_path).resolve().parents:
+                print('WARNING!! Path %s from extension %s is outside target directory'
+                      'and cannot be written out, skipping' % (file_path, active_extension.get_name()))
+                continue
+            Path(os.path.dirname(full_path)).mkdir(exist_ok=True, parents=True)
             with open(full_path, 'w') as fh:
                 print('Writing to file %s' % full_path)
                 fh.write(contents)

--- a/test/test_file_writing.py
+++ b/test/test_file_writing.py
@@ -48,10 +48,9 @@ class TestFileInjection(RockerExtension):
 
     def get_files(self, cliargs):
         all_files = {}
-        all_files['test_file.txt'] = """The quick brown fox jumped over the lazy dog.
-%s""" % cliargs
-        all_files['path/to/test_file.txt'] = """The quick brown fox jumped over the lazy dog.
-%s""" % cliargs
+        all_files['test_file.txt'] = """The quick brown fox jumped over the lazy dog. %s""" % cliargs
+        all_files['path/to/test_file.txt'] = """The quick brown fox jumped over the lazy dog. %s""" % cliargs
+        all_files['../outside/path/to/test_file.txt'] = """Path outside directory should be skipped"""
         all_files['/absolute.txt'] = """Absolute file path should be skipped"""
         return all_files
 
@@ -97,4 +96,5 @@ class FileInjectionExtensionTest(unittest.TestCase):
                 self.assertIn('test_key', content)
                 self.assertIn('test_value', content)
 
+            self.assertFalse(os.path.exists('../outside/path/to/test_file.txt'))
             self.assertFalse(os.path.exists('/absolute.txt'))

--- a/test/test_file_writing.py
+++ b/test/test_file_writing.py
@@ -50,6 +50,8 @@ class TestFileInjection(RockerExtension):
         all_files = {}
         all_files['test_file.txt'] = """The quick brown fox jumped over the lazy dog.
 %s""" % cliargs
+        all_files['path/to/test_file.txt'] = """The quick brown fox jumped over the lazy dog.
+%s""" % cliargs
         all_files['/absolute.txt'] = """Absolute file path should be skipped"""
         return all_files
 
@@ -84,6 +86,12 @@ class FileInjectionExtensionTest(unittest.TestCase):
             write_files(extensions, mock_cliargs, td)
 
             with open(os.path.join(td, 'test_file.txt'), 'r') as fh:
+                content = fh.read()
+                self.assertIn('quick brown', content)
+                self.assertIn('test_key', content)
+                self.assertIn('test_value', content)
+
+            with open(os.path.join(td, 'path/to/test_file.txt'), 'r') as fh:
                 content = fh.read()
                 self.assertIn('quick brown', content)
                 self.assertIn('test_key', content)


### PR DESCRIPTION
This simple change will allow an extension to have a directory structure for the files to copy into the container. This can simplify structuring the directory in the container if you simply wish to preserve the structure from the host machine.