### PR TITLE
Allow binary files to be copied into the build context

### DIFF
--- a/src/rocker/core.py
+++ b/src/rocker/core.py
@@ -422,7 +422,8 @@ def write_files(extensions, args_dict, target_directory):
                       'and cannot be written out, skipping' % (file_path, active_extension.get_name()))
                 continue
             Path(os.path.dirname(full_path)).mkdir(exist_ok=True, parents=True)
-            with open(full_path, 'w') as fh:
+            mode = 'wb' if isinstance(contents, bytes) else 'w' # check to see if contents should be written as binary
+            with open(full_path, mode) as fh:
                 print('Writing to file %s' % full_path)
                 fh.write(contents)
     return all_files

--- a/test/test_file_writing.py
+++ b/test/test_file_writing.py
@@ -50,6 +50,7 @@ class TestFileInjection(RockerExtension):
         all_files = {}
         all_files['test_file.txt'] = """The quick brown fox jumped over the lazy dog. %s""" % cliargs
         all_files['path/to/test_file.txt'] = """The quick brown fox jumped over the lazy dog. %s""" % cliargs
+        all_files['test_file.bin'] = bytes("""The quick brown fox jumped over the lazy dog. %s""" % cliargs, 'utf-8')
         all_files['../outside/path/to/test_file.txt'] = """Path outside directory should be skipped"""
         all_files['/absolute.txt'] = """Absolute file path should be skipped"""
         return all_files
@@ -91,6 +92,12 @@ class FileInjectionExtensionTest(unittest.TestCase):
                 self.assertIn('test_value', content)
 
             with open(os.path.join(td, 'path/to/test_file.txt'), 'r') as fh:
+                content = fh.read()
+                self.assertIn('quick brown', content)
+                self.assertIn('test_key', content)
+                self.assertIn('test_value', content)
+
+            with open(os.path.join(td, 'test_file.bin'), 'r') as fh: # this particular binary file can be read in text mode
                 content = fh.read()
                 self.assertIn('quick brown', content)
                 self.assertIn('test_key', content)


### PR DESCRIPTION
The current write routine will not work if the data is a `bytes` type. This can happen if the `get_files` function reads in a file using the `b` mode (appropriate if it's a binary file).

This change simply checks if the data is a `bytes` class and sets the write mode accordingly