### PR TITLE
Add `-v /dev:/dev` to  X11 default argument to fix libGL error: MESA-LOADER

### DIFF
--- a/src/rocker/nvidia_extension.py
+++ b/src/rocker/nvidia_extension.py
@@ -49,7 +49,7 @@ class X11(RockerExtension):
         return "  -e DISPLAY -e TERM \
   -e QT_X11_NO_MITSHM=1 \
   -e XAUTHORITY=%(xauth)s -v %(xauth)s:%(xauth)s \
-  -v /tmp/.X11-unix:/tmp/.X11-unix \
+  -v /tmp/.X11-unix:/tmp/.X11-unix -v /dev:/dev \
   -v /etc/localtime:/etc/localtime:ro " % locals()
 
     def precondition_environment(self, cliargs):


### PR DESCRIPTION
On freshly install Ubuntu 22.04 Jammy LTS. Without doing anything,
I've installed rocker with,
```bash
pip3 install rocker
pip3 install --force-reinstall git+https://github.com/osrf/rocker.git@main
rocker --version
# rocker 0.2.12
```
and ran Example in README
```bash
rocker --nvidia --x11 osrf/ros:noetic-desktop-full gazebo
```

and Got error saying
```
libGL error: MESA-LOADER: failed to retrieve device information
```

I was able to fix the problem by adding `--volume /dev:/dev` in rocker argument. which adds `-v /dev:/dev` to docker argument.
```bash
rocker --volume /dev:/dev --nvidia --x11 osrf/ros:noetic-desktop-full gazebo
```

I believe the right position to add `-v /dev:/dev` is `--x11` argument tag since it wouldn't break even if /dev doesn't exist.


Related articles
https://github.com/osrf/rocker/issues/257
https://github.com/osrf/rocker/issues/206
https://github.com/kinu-garage/hut_10sqft/issues/819
