### PR TITLE
Update deb platforms for release

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -3,5 +3,5 @@ Debian-Version: 100
 No-Python2:
 Depends3: python3-docker, python3-empy, python3-pexpect, python3-packaging
 Conflicts3: python-rocker
-Suite: bionic focal jammy stretch buster bullseye bookworm
+Suite: focal jammy noble bookworm trixie
 X-Python3-Version: >= 3.2


### PR DESCRIPTION
Added:
* Ubuntu Noble (24.04 LTS pre-release)
* Debian Trixie (testing)

Dropped:
* Debian Stretch (oldoldoldstable)
* Debian Buster (oldoldstable)
* Debian Bullseye (oldstable)
* Ubuntu Bionic (18.04 LTS)

Retained:
* Debian Bookworm (stable)
* Ubuntu Focal (20.04 LTS)
* Ubuntu Jammy (22.04 LTS)