### PR TITLE
Remove deprecated use of pkg_resources

### DIFF
--- a/.github/workflows/basic-ci.yaml
+++ b/.github/workflows/basic-ci.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: [3.8, '3.10']
+        python-version: ['3.6', '3.8', 3.x]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/basic-ci.yaml
+++ b/.github/workflows/basic-ci.yaml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: [3.8, '3.10']
+        python-version: [3.8, '3.x']
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/basic-ci.yaml
+++ b/.github/workflows/basic-ci.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ['3.6', '3.8', 3.x]
+        python-version: ['3.8', 3.x]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,11 @@
 import os
 from setuptools import setup
 
+# importlib-metadata dependency can be removed when RHEL8 and other 3.6 based systems are not in support cycles
+
 install_requires = [
     'empy',
+    'importlib-metadata; python_version < "3.8"',
     'pexpect',
     'packaging',
     'urllib3',

--- a/src/rocker/core.py
+++ b/src/rocker/core.py
@@ -19,7 +19,13 @@ import pwd
 import re
 import sys
 
-import pkg_resources
+# importlib-metadata dependency can be removed when RHEL8 and other 3.6 based systems are not in support cycles
+if sys.version_info >= (3, 8):
+    import importlib.metadata as importlib_metadata
+else:
+    import importlib_metadata
+
+
 import pkgutil
 from requests.exceptions import ConnectionError
 import shlex
@@ -459,7 +465,7 @@ def list_plugins(extension_point='rocker.extensions'):
     unordered_plugins = {
     entry_point.name: entry_point.load()
     for entry_point
-    in pkg_resources.iter_entry_points(extension_point)
+    in importlib_metadata.entry_points().select(group=extension_point)
     }
     # Order plugins by extension point name for consistent ordering below
     plugin_names = list(unordered_plugins.keys())
@@ -468,4 +474,4 @@ def list_plugins(extension_point='rocker.extensions'):
 
 
 def get_rocker_version():
-    return pkg_resources.require('rocker')[0].version
+    return importlib_metadata.version('rocker')

--- a/src/rocker/core.py
+++ b/src/rocker/core.py
@@ -461,11 +461,26 @@ def generate_dockerfile(extensions, args_dict, base_image):
     return dockerfile_str
 
 
+def list_entry_points():
+    entry_points = importlib_metadata.entry_points()
+    if hasattr(entry_points, 'select'):
+        styles_groups = entry_points.select(group='flake8_import_order.styles')
+    else:
+        styles_groups = entry_points.get('flake8_import_order.styles', [])
+
+    return styles_groups
+
 def list_plugins(extension_point='rocker.extensions'):
+
+    all_entry_points = importlib_metadata.entry_points()
+    if hasattr(all_entry_points, 'select'):
+        rocker_extensions = all_entry_points.select(group=extension_point)
+    else:
+        rocker_extensions = all_entry_points.get(extension_point, [])
+
     unordered_plugins = {
     entry_point.name: entry_point.load()
-    for entry_point
-    in importlib_metadata.entry_points().select(group=extension_point)
+    for entry_point in rocker_extensions
     }
     # Order plugins by extension point name for consistent ordering below
     plugin_names = list(unordered_plugins.keys())


### PR DESCRIPTION
This fixes #253 and lets us be forward compatible to python 3.12