### PR TITLE
switch to use get_name() instead of .name

### DIFF
--- a/src/rocker/core.py
+++ b/src/rocker/core.py
@@ -426,13 +426,13 @@ def generate_dockerfile(extensions, args_dict, base_image):
     dockerfile_str = ''
     # Preamble snippets
     for el in extensions:
-        dockerfile_str += '# Preamble from extension [%s]\n' % el.name
+        dockerfile_str += '# Preamble from extension [%s]\n' % el.get_name()
         dockerfile_str += el.get_preamble(args_dict) + '\n'
     dockerfile_str += '\nFROM %s\n' % base_image
     # ROOT snippets
     dockerfile_str += 'USER root\n'
     for el in extensions:
-        dockerfile_str += '# Snippet from extension [%s]\n' % el.name
+        dockerfile_str += '# Snippet from extension [%s]\n' % el.get_name()
         dockerfile_str += el.get_snippet(args_dict) + '\n'
     # Set USER if user extension activated
     if 'user' in args_dict and args_dict['user']:
@@ -443,7 +443,7 @@ def generate_dockerfile(extensions, args_dict, base_image):
         dockerfile_str += f'USER {username}\n'
     # USER snippets
     for el in extensions:
-        dockerfile_str += '# User Snippet from extension [%s]\n' % el.name
+        dockerfile_str += '# User Snippet from extension [%s]\n' % el.get_name()
         dockerfile_str += el.get_user_snippet(args_dict) + '\n'
     return dockerfile_str
 

--- a/test/test_volume.py
+++ b/test/test_volume.py
@@ -45,19 +45,19 @@ class VolumeTest(unittest.TestCase):
         """Passing source path"""
         arg = [[self._curr_path]]
         expected = [['{}:{}'.format(self._curr_path, self._curr_path)]]
-        mock_cliargs = {Volume.name: arg}
+        mock_cliargs = {Volume.get_name(): arg}
         self._test_equals_args(mock_cliargs, expected)
 
     def test_args_twopaths(self):
         """Passing source path, dest path"""
         arg = ["{}:{}".format(self._curr_path, self._virtual_path)]
-        mock_cliargs = {Volume.name: [arg]}
+        mock_cliargs = {Volume.get_name(): [arg]}
         self._test_equals_args(mock_cliargs, arg)
 
     def test_args_twopaths_opt(self):
         """Passing source path, dest path, and Docker's volume option"""
         arg = ["{}:{}:ro".format(self._curr_path, self._virtual_path)]
-        mock_cliargs = {Volume.name: [arg]}
+        mock_cliargs = {Volume.get_name(): [arg]}
         self._test_equals_args(mock_cliargs, arg)
 
     def test_args_two_volumes(self):
@@ -65,5 +65,5 @@ class VolumeTest(unittest.TestCase):
         arg_first = ["{}:{}:ro".format(self._curr_path, self._virtual_path)]
         arg_second = ["/tmp:{}".format(os.path.join(self._virtual_path, "tmp"))]
         args = [arg_first, arg_second]
-        mock_cliargs = {Volume.name: args}
+        mock_cliargs = {Volume.get_name(): args}
         self._test_equals_args(mock_cliargs, args)


### PR DESCRIPTION
Avoid internal calls to .name which were violating the minimal definition of a rocker extension point.

First half of #245 