### PR TITLE
[git extension] fix existing user_override_name key, but with None value

### DIFF
--- a/src/rocker/git_extension.py
+++ b/src/rocker/git_extension.py
@@ -35,7 +35,9 @@ class Git(RockerExtension):
         user_gitconfig = cli_args.get('git_config_path', os.path.expanduser('~/.gitconfig'))
         user_gitconfig_target = '/root/.gitconfig'
         if 'user' in cli_args and cli_args['user']:
-            username = cli_args.get('user_override_name', getpass.getuser())
+            username = getpass.getuser()
+            if 'user_override_name' in cli_args and cli_args['user_override_name']:
+                username = cli_args['user_override_name']
             user_gitconfig_target = '/home/%(username)s/.gitconfig' % locals()
         if os.path.exists(system_gitconfig):
             args += ' -v {system_gitconfig}:{system_gitconfig_target}:ro'.format(**locals())

--- a/test/test_git_extension.py
+++ b/test/test_git_extension.py
@@ -57,7 +57,7 @@ class GitExtensionTest(unittest.TestCase):
 
         p = git_plugin()
         self.assertTrue(plugin_load_parser_correctly(git_plugin))
-        
+
 
         mock_cliargs = {}
         mock_config_file = tempfile.NamedTemporaryFile()
@@ -75,6 +75,12 @@ class GitExtensionTest(unittest.TestCase):
         # Test with user "enabled"
         mock_cliargs = {'user': True}
         mock_cliargs['git_config_path'] = mock_config_file.name
+        user_args = p.get_docker_args(mock_cliargs)
+        user_gitconfig_target = os.path.expanduser('~/.gitconfig')
+        self.assertIn('-v %s:%s' % (user_gitconfig, user_gitconfig_target), user_args)
+
+        # Test with an existing overridden user key, but with None value
+        mock_cliargs['user_override_name'] = None
         user_args = p.get_docker_args(mock_cliargs)
         user_gitconfig_target = os.path.expanduser('~/.gitconfig')
         self.assertIn('-v %s:%s' % (user_gitconfig, user_gitconfig_target), user_args)


### PR DESCRIPTION
When trying to `git commit` found out that the `~/.gitconfig` file was mounted to `/home/None/.gitconfig`.
The corresponding test is also added.