### PR TITLE
Fix --user arg when using empy 4

### DIFF
--- a/src/rocker/templates/user_snippet.Dockerfile.em
+++ b/src/rocker/templates/user_snippet.Dockerfile.em
@@ -23,9 +23,9 @@ RUN existing_user_by_uid=`getent passwd "@(uid)" | cut -f1 -d: || true` && \
       existing_group_by_name=`getent group ${groupinfo%;*} || true`; \
       existing_group_by_gid=`getent group ${groupinfo#*;} || true`; \
       if [ -z "${existing_group_by_name}" ] && [ -z "${existing_group_by_gid}" ]; then \
-        groupadd -g "${groupinfo#*;}" "${groupinfo%;*}" && usermod -aG "${groupinfo%;*}" "@(name)" @(('|| (true && echo "user-preserve-group-permissive Enabled, continuing without processing group $groupinfo" )') if user_preserve_groups_permissive else '') || (echo "Failed to add group ${groupinfo%;*}, consider option --user-preserve-group-permissive" && exit 2); \
+        groupadd -g "${groupinfo#*;}" "${groupinfo%;*}" && usermod -aG "${groupinfo%;*}" "@(name)" @( ('|| (true && echo "user-preserve-group-permissive Enabled, continuing without processing group $groupinfo" )') if user_preserve_groups_permissive else '') || (echo "Failed to add group ${groupinfo%;*}, consider option --user-preserve-group-permissive" && exit 2); \
       elif [ "${existing_group_by_name}" = "${existing_group_by_gid}" ]; then \
-        usermod -aG "${groupinfo%;*}" "@(name)" @(('|| (true && echo "user-preserve-group-permissive Enabled, continuing without processing group $groupinfo" )') if user_preserve_groups_permissive else '') || (echo "Failed to adjust group ${groupinfo%;*}, consider option --user-preserve-group-permissive" && exit 2); \
+        usermod -aG "${groupinfo%;*}" "@(name)" @( ('|| (true && echo "user-preserve-group-permissive Enabled, continuing without processing group $groupinfo" )') if user_preserve_groups_permissive else '') || (echo "Failed to adjust group ${groupinfo%;*}, consider option --user-preserve-group-permissive" && exit 2); \
       fi; \
     done && \
 @[end if]@


### PR DESCRIPTION
[Empy 4.1 added support for extension markup @((...))](http://www.alcyone.com/software/empy/ANNOUNCE.html#recent-release-history-since-3-x), which makes rocker fail when using passing the `--user` argument as the snippet uses `@((` in some places.

Without these changes, we get this traceback when using empy 4.1

```
(rocker_venv) ➜  rocker_venv pip install rocker 
Requirement already satisfied: rocker in ./lib/python3.10/site-packages (0.2.15)
Requirement already satisfied: urllib3 in ./lib/python3.10/site-packages (from rocker) (2.2.1)
Requirement already satisfied: pexpect in ./lib/python3.10/site-packages (from rocker) (4.9.0)
Requirement already satisfied: packaging in ./lib/python3.10/site-packages (from rocker) (24.0)
Requirement already satisfied: docker in ./lib/python3.10/site-packages (from rocker) (7.0.0)
Requirement already satisfied: empy in ./lib/python3.10/site-packages (from rocker) (4.1)
Requirement already satisfied: requests>=2.26.0 in ./lib/python3.10/site-packages (from docker->rocker) (2.31.0)
Requirement already satisfied: ptyprocess>=0.5 in ./lib/python3.10/site-packages (from pexpect->rocker) (0.7.0)
Requirement already satisfied: idna<4,>=2.5 in ./lib/python3.10/site-packages (from requests>=2.26.0->docker->rocker) (3.6)
Requirement already satisfied: charset-normalizer<4,>=2 in ./lib/python3.10/site-packages (from requests>=2.26.0->docker->rocker) (3.3.2)
Requirement already satisfied: certifi>=2017.4.17 in ./lib/python3.10/site-packages (from requests>=2.26.0->docker->rocker) (2024.2.2)
(rocker_venv) ➜  rocker_venv rocker --user ubuntu:22.04
Extension volume doesn't support default arguments. Please extend it.
Active extensions ['user']
Traceback (most recent call last):
  File "/home/gary/rocker_venv/bin/rocker", line 8, in <module>
    sys.exit(main())
  File "/home/gary/rocker_venv/lib/python3.10/site-packages/rocker/cli.py", line 67, in main
    dig = DockerImageGenerator(active_extensions, args_dict, base_image)
  File "/home/gary/rocker_venv/lib/python3.10/site-packages/rocker/core.py", line 303, in __init__
    self.dockerfile = generate_dockerfile(active_extensions, self.cliargs, base_image)
  File "/home/gary/rocker_venv/lib/python3.10/site-packages/rocker/core.py", line 449, in generate_dockerfile
    dockerfile_str += el.get_snippet(args_dict) + '\n'
  File "/home/gary/rocker_venv/lib/python3.10/site-packages/rocker/extensions.py", line 321, in get_snippet
    return empy_expand(snippet, substitutions)
  File "/home/gary/rocker_venv/lib/python3.10/site-packages/rocker/em.py", line 23, in empy_expand
    return em.expand(template, globals=substitution_variables)
  File "/home/gary/rocker_venv/bin/em.py", line 5961, in expand
    result = interp.expand(data, locals, name, dispatcher=None)
  File "/home/gary/rocker_venv/bin/em.py", line 4681, in expand
    self.string(data, locals, dispatcher)
  File "/home/gary/rocker_venv/bin/em.py", line 4830, in string
    while not self.safe(scanner, True, locals, dispatcher):
  File "/home/gary/rocker_venv/bin/em.py", line 4862, in safe
    if dispatcher():
  File "/home/gary/rocker_venv/bin/em.py", line 4843, in safe
    return self.parse(scanner, locals)
  File "/home/gary/rocker_venv/bin/em.py", line 4870, in parse
    token = scanner.one()
  File "/home/gary/rocker_venv/bin/em.py", line 3999, in one
    token.scan(self)
  File "/home/gary/rocker_venv/bin/em.py", line 2648, in scan
    self.subscan(scanner, self.type)
  File "/home/gary/rocker_venv/bin/em.py", line 2664, in subscan
    token = scanner.one()
  File "/home/gary/rocker_venv/bin/em.py", line 3999, in one
    token.scan(self)
  File "/home/gary/rocker_venv/bin/em.py", line 2648, in scan
    self.subscan(scanner, self.type)
  File "/home/gary/rocker_venv/bin/em.py", line 2664, in subscan
    token = scanner.one()
  File "/home/gary/rocker_venv/bin/em.py", line 3995, in one
    raise ParseError("unknown markup sequence: `%s%s`%s" % (self.config.prefix, first, self.factory.addendum(first)))
em.ParseError: unknown markup sequence: `@((`; extension markup `@((...))` invoked with no installed extension
```