### PR TITLE
Add IPC support to RockerExtension

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ You can get full details on the extensions from the main `rocker --help` command
 - pulse -- Mount pulse audio into the container
 - ssh -- Pass through ssh access to the container.
 
-As well as access to many of the docker arguments as well such as `device`, `env`, `volume`, `name`, `network`, and `privileged`.
+As well as access to many of the docker arguments as well such as `device`, `env`, `volume`, `name`, `network`, `ipc`, and `privileged`.
 
 ### Externally maintained extensions
 

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ kwargs = {
             'hostname = rocker.extensions:Hostname',
             'name = rocker.extensions:Name',
             'network = rocker.extensions:Network',
+            'ipc = rocker.extensions:IPC',
             'nvidia = rocker.nvidia_extension:Nvidia',
             'port = rocker.extensions:Port',
             'privileged = rocker.extensions:Privileged',

--- a/src/rocker/extensions.py
+++ b/src/rocker/extensions.py
@@ -162,6 +162,26 @@ class Network(RockerExtension):
             default=defaults.get('network', None),
             help="What network configuration to use.")
 
+class IPC(RockerExtension):
+    @staticmethod
+    def get_name():
+        return 'ipc'
+    def __init__(self):
+        self.name = IPC.get_name()
+
+    def get_preamble(self, cliargs):
+        return ''
+    
+    def get_docker_args(self, cliargs):
+        args = ''
+        ipc = cliargs.get('ipc', None)
+        args += ' --ipc %s ' % ipc
+        return args
+    
+    @staticmethod
+    def register_arguments(parser, defaults={}):
+        parser.add_argument('--ipc', default=defaults.get('ipc', 'private'),
+                            help='IPC namespace to use.')
 
 class Expose(RockerExtension):
     @staticmethod


### PR DESCRIPTION
- Introduced a new IPC class that extends RockerExtension to handle IPC namespace options.
- Implemented `get_name` to return the 'ipc' identifier.
- Added `get_docker_args` method to generate Docker IPC arguments based on CLI input.
- Included a `get_preamble` method that returns an empty string as no preamble is needed.

This PR enables the use of IPC-related Docker arguments in Rocker configurations and should close the issue #241. 

