### PR TITLE
Set the defaults argument to None to fix dangerous-default-value linter warning

### DIFF
--- a/src/rocker/core.py
+++ b/src/rocker/core.py
@@ -117,7 +117,9 @@ class RockerExtension(object):
         return True if cli_args.get(cls.get_name()) else False
 
     @staticmethod
-    def register_arguments(parser, defaults={}):
+    def register_arguments(parser, defaults:dict=None):
+        if defaults is None:
+            defaults={}
         raise NotImplementedError
 
 


### PR DESCRIPTION
I made a rocker extension the other day and was getting the dangerous-default-value linter warning on the register_arguments() function.

https://pylint.pycqa.org/en/latest/user_guide/messages/warning/dangerous-default-value.html

I applied the standard fix it my code to remove the warning, but thought it could be fixed upstream as well so when people make a new extension they will not have to fix it themselves.

