### PR TITLE
Add support for ulimit flag

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ kwargs = {
         'console_scripts': [
             'rocker = rocker.cli:main',
             'detect_docker_image_os = rocker.cli:detect_image_os',
-	    ],
+        ],
         'rocker.extensions': [
             'cuda = rocker.nvidia_extension:Cuda',
             'devices = rocker.extensions:Devices',
@@ -66,8 +66,9 @@ kwargs = {
             'user = rocker.extensions:User',
             'volume = rocker.volume_extension:Volume',
             'x11 = rocker.nvidia_extension:X11',
+            'ulimit = rocker.ulimit_extension:Ulimit',
         ]
-	},
+    },
     'author': 'Tully Foote',
     'author_email': 'tfoote@osrfoundation.org',
     'keywords': ['Docker'],
@@ -91,4 +92,3 @@ kwargs = {
 }
 
 setup(**kwargs)
-

--- a/setup.py
+++ b/setup.py
@@ -63,10 +63,10 @@ kwargs = {
             'pulse = rocker.extensions:PulseAudio',
             'rmw = rocker.rmw_extension:RMW',
             'ssh = rocker.ssh_extension:Ssh',
+            'ulimit = rocker.ulimit_extension:Ulimit',
             'user = rocker.extensions:User',
             'volume = rocker.volume_extension:Volume',
             'x11 = rocker.nvidia_extension:X11',
-            'ulimit = rocker.ulimit_extension:Ulimit',
         ]
     },
     'author': 'Tully Foote',

--- a/src/rocker/ulimit_extension.py
+++ b/src/rocker/ulimit_extension.py
@@ -1,0 +1,40 @@
+# Copyright 2019 Open Source Robotics Foundation
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from argparse import ArgumentTypeError
+import os
+from rocker.extensions import RockerExtension
+
+
+class Ulimit(RockerExtension):
+
+    ARG_DOCKER_ULIMIT = "--ulimit"
+    ARG_ROCKER_VOLUME = "--ulimit"
+    name = 'ulimit'
+
+    @classmethod
+    def get_name(cls):
+        return cls.name
+
+    def get_docker_args(self, cliargs):
+        args = ['']
+        return ' '.join(args)
+
+    @staticmethod
+    def register_arguments(parser, defaults):
+        parser.add_argument(Ulimit.ARG_ROCKER_VOLUME,
+                            type=str,
+                            nargs='+',
+                            action='append',
+                            help='ulimit options to add into the container.')

--- a/src/rocker/ulimit_extension.py
+++ b/src/rocker/ulimit_extension.py
@@ -21,15 +21,13 @@ class Ulimit(RockerExtension):
 
     ARG_DOCKER_ULIMIT = "--ulimit"
     ARG_ROCKER_VOLUME = "--ulimit"
-    name = 'ulimit'
 
-    @classmethod
-    def get_name(cls):
-        return cls.name
+    @staticmethod
+    def get_name():
+        return 'ulimit'
 
     def get_docker_args(self, cliargs):
-        args = ['']
-        return ' '.join(args)
+        return ''
 
     @staticmethod
     def register_arguments(parser, defaults):

--- a/src/rocker/ulimit_extension.py
+++ b/src/rocker/ulimit_extension.py
@@ -14,13 +14,11 @@
 
 from argparse import ArgumentTypeError
 import os
-from rocker.extensions import RockerExtension
+from rocker.extensions import RockerExtension, name_to_argument
 
 
 class Ulimit(RockerExtension):
-
-    ARG_DOCKER_ULIMIT = "--ulimit"
-    ARG_ROCKER_VOLUME = "--ulimit"
+    EXPECTED_FORMAT = "TYPE=SOFT_LIMIT[:HARD_LIMIT]"
 
     @staticmethod
     def get_name():
@@ -31,8 +29,10 @@ class Ulimit(RockerExtension):
 
     @staticmethod
     def register_arguments(parser, defaults):
-        parser.add_argument(Ulimit.ARG_ROCKER_VOLUME,
+        parser.add_argument(name_to_argument(Ulimit.get_name()),
                             type=str,
                             nargs='+',
                             action='append',
+                            metavar=Ulimit.EXPECTED_FORMAT,
+                            default=defaults.get(Ulimit.get_name(), None),
                             help='ulimit options to add into the container.')

--- a/test/test_ulimit.py
+++ b/test/test_ulimit.py
@@ -68,3 +68,33 @@ class UlimitTest(unittest.TestCase):
         mock_cliargs = ["rtprio=99", "memlock=102400", "nofile=1024:524288"]
         expected = " --ulimit rtprio=99 --ulimit memlock=102400 --ulimit nofile=1024:524288"
         self.assertTrue(self._is_arg_translation_ok(mock_cliargs, expected))
+
+    def test_args_wrong_single_soft(self):
+        """Test if single soft limit argument is wrong."""
+        mock_cliargs = ["rtprio99"]
+        expected = " --ulimit rtprio99"
+        self.assertFalse(self._is_arg_translation_ok(mock_cliargs, expected))
+
+    def test_args_wrong_multiple_soft(self):
+        """Test if multiple soft limit arguments are wrong."""
+        mock_cliargs = ["rtprio=99", "memlock102400"]
+        expected = " --ulimit rtprio=99 --ulimit memlock=102400"
+        self.assertFalse(self._is_arg_translation_ok(mock_cliargs, expected))
+
+    def test_args_wrong_single_hard(self):
+        """Test if single hard limit arguments are wrong."""
+        mock_cliargs = ["nofile=1024:524288:"]
+        expected = " --ulimit nofile=1024:524288"
+        self.assertFalse(self._is_arg_translation_ok(mock_cliargs, expected))
+
+    def test_args_wrong_multiple_hard(self):
+        """Test if multiple hard limit arguments are wrong."""
+        mock_cliargs = ["nofile1024524288", "rtprio=90:99"]
+        expected = " --ulimit nofile=1024:524288 --ulimit rtprio=90:99"
+        self.assertFalse(self._is_arg_translation_ok(mock_cliargs, expected))
+
+    def test_args_wrong_multiple_mix(self):
+        """Test if multiple mixed limit arguments are wrong."""
+        mock_cliargs = ["rtprio=:", "memlock102400", "nofile1024:524288:"]
+        expected = " --ulimit rtprio=99 --ulimit memlock=102400 --ulimit nofile=1024:524288"
+        self.assertFalse(self._is_arg_translation_ok(mock_cliargs, expected))

--- a/test/test_ulimit.py
+++ b/test/test_ulimit.py
@@ -1,0 +1,66 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import os
+import unittest
+
+from rocker.ulimit_extension import Ulimit
+
+
+class UlimitTest(unittest.TestCase):
+    """Unit tests for the Ulimit class."""
+
+    def setUp(self):
+        self._instance = Ulimit()
+        self._curr_path = os.path.abspath(os.path.curdir)
+        self._virtual_path = "/path/in/container"
+
+    def _is_arg_translation_ok(self, mock_cliargs, expected):
+        docker_args = self._instance.get_docker_args({self._instance.get_name(): [mock_cliargs]})
+        print(f"DEBUG: Expected docker_args: {expected}")
+        print(f"DEBUG: Resulted docker_args: {docker_args}")
+        self.assertTrue(docker_args == expected)
+
+    def test_args_single_soft(self):
+        """Test single soft limit argument."""
+        mock_cliargs = ["rtprio=99"]
+        expected = " --ulimit rtprio=99"
+        self._is_arg_translation_ok(mock_cliargs, expected)
+
+    def test_args_multiple_soft(self):
+        """Test multiple soft limit arguments."""
+        mock_cliargs = ["rtprio=99", "memlock=102400"]
+        expected = " --ulimit rtprio=99 --ulimit memlock=102400"
+        self._is_arg_translation_ok(mock_cliargs, expected)
+
+    def test_args_single_hard(self):
+        """Test single hard limit argument."""
+        mock_cliargs = ["nofile=1024:524288"]
+        expected = " --ulimit nofile=1024:524288"
+        self._is_arg_translation_ok(mock_cliargs, expected)
+
+    def test_args_multiple_hard(self):
+        """Test multiple hard limit arguments."""
+        mock_cliargs = ["nofile=1024:524288", "rtprio=90:99"]
+        expected = " --ulimit nofile=1024:524288 --ulimit rtprio=90:99"
+        self._is_arg_translation_ok(mock_cliargs, expected)
+
+    def test_args_multiple_mix(self):
+        """Test multiple mixed limit arguments."""
+        mock_cliargs = ["rtprio=99", "memlock=102400", "nofile=1024:524288"]
+        expected = " --ulimit rtprio=99 --ulimit memlock=102400 --ulimit nofile=1024:524288"
+        self._is_arg_translation_ok(mock_cliargs, expected)

--- a/test/test_ulimit.py
+++ b/test/test_ulimit.py
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import os
 import unittest
 
 from rocker.ulimit_extension import Ulimit
@@ -26,8 +25,6 @@ class UlimitTest(unittest.TestCase):
 
     def setUp(self):
         self._instance = Ulimit()
-        self._curr_path = os.path.abspath(os.path.curdir)
-        self._virtual_path = "/path/in/container"
 
     def _is_arg_translation_ok(self, mock_cliargs, expected):
         docker_args = self._instance.get_docker_args({self._instance.get_name(): [mock_cliargs]})

--- a/test/test_ulimit.py
+++ b/test/test_ulimit.py
@@ -29,72 +29,72 @@ class UlimitTest(unittest.TestCase):
 
     def _is_arg_translation_ok(self, mock_cliargs, expected):
         is_ok = False
+        message_string = ""
         try:
             docker_args = self._instance.get_docker_args(
                 {self._instance.get_name(): [mock_cliargs]})
             is_ok = docker_args == expected
-            print(f"DEBUG: Expected docker_args: {expected}")
-            print(f"DEBUG: Resulted docker_args: {docker_args}")
+            message_string = f"Expected: '{expected}', got: '{docker_args}'"
         except ArgumentTypeError:
-            print("DEBUG: Incorrect argument format")
-        return is_ok
+            message_string = "Incorrect argument format"
+        return (is_ok, message_string)
 
     def test_args_single_soft(self):
         """Test single soft limit argument."""
         mock_cliargs = ["rtprio=99"]
         expected = " --ulimit rtprio=99"
-        self.assertTrue(self._is_arg_translation_ok(mock_cliargs, expected))
+        self.assertTrue(*self._is_arg_translation_ok(mock_cliargs, expected))
 
     def test_args_multiple_soft(self):
         """Test multiple soft limit arguments."""
         mock_cliargs = ["rtprio=99", "memlock=102400"]
         expected = " --ulimit rtprio=99 --ulimit memlock=102400"
-        self.assertTrue(self._is_arg_translation_ok(mock_cliargs, expected))
+        self.assertTrue(*self._is_arg_translation_ok(mock_cliargs, expected))
 
     def test_args_single_hard(self):
         """Test single hard limit argument."""
         mock_cliargs = ["nofile=1024:524288"]
         expected = " --ulimit nofile=1024:524288"
-        self.assertTrue(self._is_arg_translation_ok(mock_cliargs, expected))
+        self.assertTrue(*self._is_arg_translation_ok(mock_cliargs, expected))
 
     def test_args_multiple_hard(self):
         """Test multiple hard limit arguments."""
         mock_cliargs = ["nofile=1024:524288", "rtprio=90:99"]
         expected = " --ulimit nofile=1024:524288 --ulimit rtprio=90:99"
-        self.assertTrue(self._is_arg_translation_ok(mock_cliargs, expected))
+        self.assertTrue(*self._is_arg_translation_ok(mock_cliargs, expected))
 
     def test_args_multiple_mix(self):
         """Test multiple mixed limit arguments."""
         mock_cliargs = ["rtprio=99", "memlock=102400", "nofile=1024:524288"]
         expected = " --ulimit rtprio=99 --ulimit memlock=102400 --ulimit nofile=1024:524288"
-        self.assertTrue(self._is_arg_translation_ok(mock_cliargs, expected))
+        self.assertTrue(*self._is_arg_translation_ok(mock_cliargs, expected))
 
     def test_args_wrong_single_soft(self):
         """Test if single soft limit argument is wrong."""
         mock_cliargs = ["rtprio99"]
         expected = " --ulimit rtprio99"
-        self.assertFalse(self._is_arg_translation_ok(mock_cliargs, expected))
+        self.assertFalse(*self._is_arg_translation_ok(mock_cliargs, expected))
 
     def test_args_wrong_multiple_soft(self):
         """Test if multiple soft limit arguments are wrong."""
         mock_cliargs = ["rtprio=99", "memlock102400"]
         expected = " --ulimit rtprio=99 --ulimit memlock=102400"
-        self.assertFalse(self._is_arg_translation_ok(mock_cliargs, expected))
+        self.assertFalse(*self._is_arg_translation_ok(mock_cliargs, expected))
 
     def test_args_wrong_single_hard(self):
         """Test if single hard limit arguments are wrong."""
         mock_cliargs = ["nofile=1024:524288:"]
         expected = " --ulimit nofile=1024:524288"
-        self.assertFalse(self._is_arg_translation_ok(mock_cliargs, expected))
+        self.assertFalse(*self._is_arg_translation_ok(mock_cliargs, expected))
 
     def test_args_wrong_multiple_hard(self):
         """Test if multiple hard limit arguments are wrong."""
         mock_cliargs = ["nofile1024524288", "rtprio=90:99"]
         expected = " --ulimit nofile=1024:524288 --ulimit rtprio=90:99"
-        self.assertFalse(self._is_arg_translation_ok(mock_cliargs, expected))
+        self.assertFalse(*self._is_arg_translation_ok(mock_cliargs, expected))
 
     def test_args_wrong_multiple_mix(self):
         """Test if multiple mixed limit arguments are wrong."""
         mock_cliargs = ["rtprio=:", "memlock102400", "nofile1024:524288:"]
         expected = " --ulimit rtprio=99 --ulimit memlock=102400 --ulimit nofile=1024:524288"
-        self.assertFalse(self._is_arg_translation_ok(mock_cliargs, expected))
+        self.assertFalse(*self._is_arg_translation_ok(mock_cliargs, expected))

--- a/test/test_ulimit.py
+++ b/test/test_ulimit.py
@@ -16,6 +16,7 @@
 # under the License.
 
 import unittest
+from argparse import ArgumentTypeError
 
 from rocker.ulimit_extension import Ulimit
 
@@ -27,37 +28,43 @@ class UlimitTest(unittest.TestCase):
         self._instance = Ulimit()
 
     def _is_arg_translation_ok(self, mock_cliargs, expected):
-        docker_args = self._instance.get_docker_args({self._instance.get_name(): [mock_cliargs]})
-        print(f"DEBUG: Expected docker_args: {expected}")
-        print(f"DEBUG: Resulted docker_args: {docker_args}")
-        self.assertTrue(docker_args == expected)
+        is_ok = False
+        try:
+            docker_args = self._instance.get_docker_args(
+                {self._instance.get_name(): [mock_cliargs]})
+            is_ok = docker_args == expected
+            print(f"DEBUG: Expected docker_args: {expected}")
+            print(f"DEBUG: Resulted docker_args: {docker_args}")
+        except ArgumentTypeError:
+            print("DEBUG: Incorrect argument format")
+        return is_ok
 
     def test_args_single_soft(self):
         """Test single soft limit argument."""
         mock_cliargs = ["rtprio=99"]
         expected = " --ulimit rtprio=99"
-        self._is_arg_translation_ok(mock_cliargs, expected)
+        self.assertTrue(self._is_arg_translation_ok(mock_cliargs, expected))
 
     def test_args_multiple_soft(self):
         """Test multiple soft limit arguments."""
         mock_cliargs = ["rtprio=99", "memlock=102400"]
         expected = " --ulimit rtprio=99 --ulimit memlock=102400"
-        self._is_arg_translation_ok(mock_cliargs, expected)
+        self.assertTrue(self._is_arg_translation_ok(mock_cliargs, expected))
 
     def test_args_single_hard(self):
         """Test single hard limit argument."""
         mock_cliargs = ["nofile=1024:524288"]
         expected = " --ulimit nofile=1024:524288"
-        self._is_arg_translation_ok(mock_cliargs, expected)
+        self.assertTrue(self._is_arg_translation_ok(mock_cliargs, expected))
 
     def test_args_multiple_hard(self):
         """Test multiple hard limit arguments."""
         mock_cliargs = ["nofile=1024:524288", "rtprio=90:99"]
         expected = " --ulimit nofile=1024:524288 --ulimit rtprio=90:99"
-        self._is_arg_translation_ok(mock_cliargs, expected)
+        self.assertTrue(self._is_arg_translation_ok(mock_cliargs, expected))
 
     def test_args_multiple_mix(self):
         """Test multiple mixed limit arguments."""
         mock_cliargs = ["rtprio=99", "memlock=102400", "nofile=1024:524288"]
         expected = " --ulimit rtprio=99 --ulimit memlock=102400 --ulimit nofile=1024:524288"
-        self._is_arg_translation_ok(mock_cliargs, expected)
+        self.assertTrue(self._is_arg_translation_ok(mock_cliargs, expected))


### PR DESCRIPTION
Hi, this PR adds support for the `ulimit` flag (https://docs.docker.com/reference/cli/docker/container/run/#ulimit). This flag is useful when running ROS 1 containers in machines with high `nofile` limits (default in Arch Linux) since not limiting this causes system crashes (please read https://answers.ros.org/question/336963/rosout-high-memory-usage/ for more info).

This PR adds:
- `Ulimit` class that extends  `RockerExtension` to add support for the `--ulimit` flag in Docker
- Checks for appropriate syntax using regex
- Descriptive message when using `help` command and when raising argument type exception (similar to the `Volume` extension)
- Basic unit tests