### PR TITLE
Feature/remove default arguments warning for volume extension

### DIFF
--- a/src/rocker/volume_extension.py
+++ b/src/rocker/volume_extension.py
@@ -61,7 +61,7 @@ class Volume(RockerExtension):
         return ' '.join(args)
 
     @staticmethod
-    def register_arguments(parser):
+    def register_arguments(parser, defaults: dict=None):
         parser.add_argument(Volume.ARG_ROCKER_VOLUME,
             metavar='HOST-DIR[:CONTAINER-DIR[:OPTIONS]]',
             type=str,

--- a/src/rocker/volume_extension.py
+++ b/src/rocker/volume_extension.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from argparse import ArgumentTypeError, ArgumentParser
+from argparse import ArgumentParser
+from argparse import ArgumentTypeError
 import os
 from rocker.extensions import RockerExtension
 

--- a/src/rocker/volume_extension.py
+++ b/src/rocker/volume_extension.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from argparse import ArgumentTypeError
+from argparse import ArgumentTypeError, ArgumentParser
 import os
 from rocker.extensions import RockerExtension
 
@@ -61,7 +61,7 @@ class Volume(RockerExtension):
         return ' '.join(args)
 
     @staticmethod
-    def register_arguments(parser, defaults: dict=None):
+    def register_arguments(parser: ArgumentParser, defaults: dict=None):
         parser.add_argument(Volume.ARG_ROCKER_VOLUME,
             metavar='HOST-DIR[:CONTAINER-DIR[:OPTIONS]]',
             type=str,


### PR DESCRIPTION
when running rocker this warning appears every time:
```bash
Extension volume doesn't support default arguments. Please extend it.
```

This sets default arguments for the volume extension to remove this warning.

It also adds type hints for the parser argument. 