### PR TITLE
Mark entire CudaTest class as requiring docker

### DIFF
--- a/test/test_nvidia.py
+++ b/test/test_nvidia.py
@@ -250,6 +250,7 @@ CMD glmark2 --validate
             p.get_environment_subs(mock_cliargs)
         self.assertEqual(cm.exception.code, 1)
 
+@pytest.mark.docker
 class CudaTest(unittest.TestCase):
     @classmethod
     def setUpClass(self):
@@ -286,7 +287,6 @@ CMD dpkg -s cuda-toolkit
         em.Interpreter._wasProxyInstalled = False
 
 
-    @pytest.mark.docker
     def test_no_cuda(self):
         for tag in self.dockerfile_tags:
             dig = DockerImageGenerator([], {}, tag)
@@ -294,7 +294,6 @@ CMD dpkg -s cuda-toolkit
             self.assertNotEqual(dig.run(), 0)
             dig.clear_image()
 
-    @pytest.mark.docker
     def test_cuda_install(self):
         plugins = list_plugins()
         desired_plugins = ['cuda']


### PR DESCRIPTION
The call to get_docker_client in setUpClass will fail if docker is not available on the host.

Resolves:
```
test/test_nvidia.py:256: in setUpClass
    client = get_docker_client()
../../install_isolated/rocker/lib/python3.12/site-packages/rocker/core.py:220: in get_docker_client
    raise DependencyMissing('Docker Client failed to connect to docker daemon.'
E   rocker.core.DependencyMissing: Docker Client failed to connect to docker daemon. Please verify that docker is installed and running. As well as that you have permission to access the docker daemon. This is usually by being a member of the docker group. The underlying error was:
E   """
E   Error while fetching server API version: ('Connection aborted.', FileNotFoundError(2, 'No such file or directory'))
E   """
```