### PR TITLE
Mark test_docker_user_setting as requiring docker

### DIFF
--- a/test/test_core.py
+++ b/test/test_core.py
@@ -239,6 +239,7 @@ class RockerCoreTest(unittest.TestCase):
         username_detected =  getattr(userinfo, 'pw_' + 'name')
         self.assertEqual(username_detected, get_user_name())
 
+    @pytest.mark.docker
     def test_docker_user_setting(self):
         parser = argparse.ArgumentParser()
         extension_manager = RockerExtensionManager()


### PR DESCRIPTION
This test calls extend_cli_parser, which will fail if docker is not available.

Resolves:
```
test/test_core.py:246: in test_docker_user_setting
    extension_manager.extend_cli_parser(parser, default_args)
../../install_isolated/rocker/lib/python3.12/site-packages/rocker/core.py:131: in extend_cli_parser
    p.register_arguments(parser, default_args)
../../install_isolated/rocker/lib/python3.12/site-packages/rocker/extensions.py:209: in register_arguments
    client = get_docker_client()
../../install_isolated/rocker/lib/python3.12/site-packages/rocker/core.py:220: in get_docker_client
    raise DependencyMissing('Docker Client failed to connect to docker daemon.'
E   rocker.core.DependencyMissing: Docker Client failed to connect to docker daemon. Please verify that docker is installed and running. As well as that you have permission to access the docker daemon. This is usually by being a member of the docker group. The underlying error was:
E   """
E   Error while fetching server API version: ('Connection aborted.', FileNotFoundError(2, 'No such file or directory'))
E   """
```