### PR TITLE
label cuda install test nvidia to skip on CI

### DIFF
--- a/test/test_nvidia.py
+++ b/test/test_nvidia.py
@@ -251,6 +251,7 @@ CMD glmark2 --validate
         self.assertEqual(cm.exception.code, 1)
 
 @pytest.mark.docker
+@pytest.mark.nvidia # Technically not needing nvidia but too resource intensive for main runs
 class CudaTest(unittest.TestCase):
     @classmethod
     def setUpClass(self):


### PR DESCRIPTION
This is the workaround for #309 to disable those tests on CI. 