### PR TITLE
Improve the robustness of image cleanup

### DIFF
--- a/src/rocker/cli.py
+++ b/src/rocker/cli.py
@@ -69,13 +69,13 @@ def main():
     exit_code = dig.build(**vars(args))
     if exit_code != 0:
         print("Build failed exiting")
-        if not args_dict['persist_image']:
+        if not (args_dict['persist_image'] or args_dict.get('image_name')):
             dig.clear_image()
         return exit_code
     # Convert command into string
     args.command = ' '.join(args.command)
     result = dig.run(**args_dict)
-    if not args_dict['persist_image']:
+    if not (args_dict['persist_image'] or args_dict.get('image_name')):
         print(f'Clearing Image: {dig.image_id}s\nTo not clean up use --persist-images')
         dig.clear_image()
     return result

--- a/src/rocker/core.py
+++ b/src/rocker/core.py
@@ -251,12 +251,24 @@ def docker_build(docker_client = None, output_callback = None, **kwargs):
         print("no more output and success not detected")
         return None
 
-def docker_remove_image(image_id, docker_client = None, output_callback = None, **kwargs):
+def docker_remove_image(
+        image_id,
+        docker_client = None,
+        output_callback = None,
+        fail_on_error = False,
+        force = False,
+        **kwargs):
 
     if not docker_client:
         docker_client = get_docker_client()
 
-    docker_client.remove_image(image_id)
+    try:
+        docker_client.remove_image(image_id, force=force)
+    except docker.errors.APIError as ex:
+        ## removing the image can fail if there's child images
+        if fail_on_error:
+            return False
+    return True
 
 class SIGWINCHPassthrough(object):
     def __init__ (self, process):
@@ -421,7 +433,8 @@ class DockerImageGenerator(object):
 
     def clear_image(self):
         if self.image_id:
-            docker_remove_image(self.image_id)
+            if not docker_remove_image(self.image_id):
+                print(f'Failed to clear image {self.image_id} it likely has child images.')
             self.image_id = None
             self.built = False
 

--- a/src/rocker/core.py
+++ b/src/rocker/core.py
@@ -254,7 +254,6 @@ def docker_build(docker_client = None, output_callback = None, **kwargs):
 def docker_remove_image(
         image_id,
         docker_client = None,
-        output_callback = None,
         fail_on_error = False,
         force = False,
         **kwargs):


### PR DESCRIPTION
Don't crash if there's a dependent image already
And don't cleanup if the user has given it a name. The name's useless if we clear it.