### PR TITLE
361: Feature cuda skip install

### DIFF
--- a/src/rocker/cli.py
+++ b/src/rocker/cli.py
@@ -37,6 +37,7 @@ def main():
     parser.add_argument('--nocleanup', action='store_true', help='do not remove the docker container when stopped')
     parser.add_argument('--persist-image', action='store_true', help='do not remove the docker image when stopped', default=False) #TODO(tfoote) Add a name to it if persisting
     parser.add_argument('--pull', action='store_true')
+    parser.add_argument('--dive', action='store_true', help='Run Dive for introspection after building the image') # 310
     parser.add_argument('--version', action='version',
         version='%(prog)s ' + get_rocker_version())
 


### PR DESCRIPTION
This pull request enhances the CUDA extension to skip the installation step if CUDA is already present on the system. It adds a check to detect whether CUDA is installed using the nvidia-smi command, ensuring that redundant installations are avoided.

**Key Changes**

1. Added function `is_cuda_installed()` to check if CUDA is already installed.
2. Modified `get_snippet()` method to: Skip generating the Dockerfile if CUDA is detected.