### PR TITLE
Restore interactive as the default behavior

### DIFF
--- a/src/rocker/cli.py
+++ b/src/rocker/cli.py
@@ -83,7 +83,7 @@ def main():
     # Right now the printed results will include '-it'
     # But based on testing the --detach overrides -it in docker so it's ok.
 
-    # Default to non-interactive if unset
+    # Default to interactive if unset
     if args_dict.get('mode') not in OPERATION_MODES:
         print("Mode unset, defaulting to interactive")
         args_dict['mode'] = OPERATIONS_INTERACTIVE


### PR DESCRIPTION
The comment is correct but this looks like it was changed in #320 by accident.

Found during the review and testing of #331 