### PR TITLE
Enhance Docker permission detection and improve error messages (Fixes #34)

### DIFF
--- a/src/rocker/cli.py
+++ b/src/rocker/cli.py
@@ -20,6 +20,7 @@ from .core import DockerImageGenerator
 from .core import get_rocker_version
 from .core import RockerExtensionManager
 from .core import DependencyMissing
+from .core import DockerPermissionError
 from .core import ExtensionError
 from .core import OPERATIONS_DRY_RUN
 from .core import OPERATIONS_INTERACTIVE
@@ -48,6 +49,12 @@ def main():
         extension_manager = RockerExtensionManager()
         default_args = {}
         extension_manager.extend_cli_parser(parser, default_args)
+    except DockerPermissionError as ex:
+        # Handle Docker permission issues with user-friendly messages
+        print("ERROR: %s" % ex)
+        if ex.suggested_fix:
+            print("\n%s" % ex.suggested_fix)
+        return 1
     except DependencyMissing as ex:
         # Catch errors if docker is missing or inaccessible.
         parser.error("DependencyMissing encountered: %s" % ex)


### PR DESCRIPTION
issue: #34 
Solution
- Added a Docker permission check that detects whether the current user can access the Docker daemon.
- When permission is denied, the CLI now displays a clear error message with step-by-step instructions to fix it.
- Retained handling for other error scenarios (daemon not running, Docker not installed, unknown errors).

Testing
- Local environment: Docker Desktop 28.3.2 (API 1.51), all unit and integration tests passed.
- Normal operation tests: image build, container run, cleanup — all passed.
- Permission-denied simulation: correctly triggered the new friendly error output without Python tracebacks.
